### PR TITLE
Fix: Correct cursor behavior in TextBox when typing with all text sel…

### DIFF
--- a/src/klooie/Controls/TextBox.cs
+++ b/src/klooie/Controls/TextBox.cs
@@ -121,12 +121,20 @@ public partial class TextBox : ConsoleControl
         else if (isAllSelected)
         {
             isAllSelected = false;
-            ConsoleCharacter? p = this.Value.Length == 0 ? null : this.Value[this.Value.Length - 1];
-            var c = new ConsoleCharacter(info.KeyChar,
-                p.HasValue ? p.Value.ForegroundColor : ConsoleString.DefaultForegroundColor,
-                p.HasValue ? p.Value.BackgroundColor : ConsoleString.DefaultBackgroundColor);
+            ConsoleCharacter? prototype = this.Value.Length == 0 ? null : this.Value[this.Value.Length - 1];
 
-            Value = RichTextCommandLineReader.IsWriteable(info) ? new ConsoleString(new ConsoleCharacter[] { c }) : ConsoleString.Empty;
+            Editor.CursorPosition = 0;
+            Editor.CurrentValue = ConsoleString.Empty;
+
+            // Only attempt to register key press if it's a writable character or a space.
+            // Other special keys like arrows, backspace are handled in earlier conditions.
+            if (RichTextCommandLineReader.IsWriteable(info) || info.Key == ConsoleKey.Spacebar)
+            {
+                Editor.RegisterKeyPress(info, prototype);
+            }
+            // If not writable and not space, CurrentValue remains Empty, effectively clearing the selection.
+
+            Value = Editor.CurrentValue; // Update Value from editor
             StartBlinking();
             return;
         }


### PR DESCRIPTION
…ected

When the TextBox had all its text selected and a character was typed, the cursor would incorrectly jump, and the new character would often be misplaced.

This was due to the `OnKeyInputReceived` method directly manipulating the `Value` property without properly utilizing the `RichTextEditor`'s capabilities for handling input when text is selected.

The fix involves the following changes within the `else if (isAllSelected)` block in `OnKeyInputReceived`:
- The `prototype` character (for styling) is now captured from the existing `Value` before any modifications.
- `Editor.CursorPosition` is explicitly set to 0.
- `Editor.CurrentValue` is set to `ConsoleString.Empty` to clear the selection in the underlying editor.
- `Editor.RegisterKeyPress(info, prototype)` is now called to handle the character input. This ensures the `RichTextEditor` correctly processes the key press, including cursor placement and text insertion. This call is made only for writable characters or the spacebar, effectively clearing the selection for other non-writable special keys.
- The TextBox's `Value` is then updated from `Editor.CurrentValue`.

This ensures that the `RichTextEditor` consistently manages text input, resolving the cursor jumping issue and leading to the correct behavior when typing into a fully selected TextBox.