### PR TITLE
Add docs and tests for LeaseHelper

### DIFF
--- a/src/klooie/Observability/LeaseHelper.cs
+++ b/src/klooie/Observability/LeaseHelper.cs
@@ -5,29 +5,80 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace klooie;
+/// <summary>
+/// Helper methods for tracking lifetimes of <see cref="Recyclable"/> objects.
+/// </summary>
 public static class LeaseHelper
 {
-    public static LeaseState<TOwner, TRecyclable> TrackOwnerRelationship<TOwner, TRecyclable>(TOwner owner, TRecyclable recyclable) where TOwner : Recyclable where TRecyclable : Recyclable 
+    /// <summary>
+    /// Creates a <see cref="LeaseState{TOwner, TRecyclable}"/> that tracks the
+    /// lease of both an owner and a recyclable object.
+    /// </summary>
+    /// <typeparam name="TOwner">The type of the owner.</typeparam>
+    /// <typeparam name="TRecyclable">The type being tracked.</typeparam>
+    /// <param name="owner">The owning object.</param>
+    /// <param name="recyclable">The recyclable object whose lifetime is being tracked.</param>
+    /// <returns>A lease state representing the owner/recyclable relationship.</returns>
+    public static LeaseState<TOwner, TRecyclable> TrackOwnerRelationship<TOwner, TRecyclable>(TOwner owner, TRecyclable recyclable) where TOwner : Recyclable where TRecyclable : Recyclable
         => LeaseState<TOwner, TRecyclable>.Create(owner, recyclable);
 
+    /// <summary>
+    /// Creates a <see cref="LeaseState{TRecyclable}"/> that tracks the lease of a single object.
+    /// </summary>
+    /// <typeparam name="TRecyclable">The type being tracked.</typeparam>
+    /// <param name="recyclable">The recyclable object to track.</param>
+    /// <returns>A lease state representing the object and its current lease.</returns>
     public static LeaseState<TRecyclable> Track<TRecyclable>(TRecyclable recyclable) where TRecyclable : Recyclable
         => LeaseState<TRecyclable>.Create(recyclable);
 }
 
+/// <summary>
+/// Represents a snapshot of the leases for an owner object and a recyclable it owns.
+/// </summary>
+/// <typeparam name="TOwner">Type of the owner.</typeparam>
+/// <typeparam name="TRecyclable">Type of the recyclable being tracked.</typeparam>
 public class LeaseState<TOwner, TRecyclable> : Recyclable where TRecyclable : Recyclable where TOwner : Recyclable
 {
     private static LazyPool<LeaseState<TOwner, TRecyclable>> pool = new LazyPool<LeaseState<TOwner, TRecyclable>>(() => new LeaseState<TOwner, TRecyclable>());
 
+    /// <summary>
+    /// The recyclable instance being tracked.
+    /// </summary>
     public TRecyclable? Recyclable { get; private set; }
+
+    /// <summary>
+    /// The owner of the recyclable instance.
+    /// </summary>
     public TOwner? Owner { get; private set; }
+
+    /// <summary>
+    /// The lease value captured for <see cref="Recyclable"/> when tracking started.
+    /// </summary>
     public int RecyclableLease { get; private set; }
+
+    /// <summary>
+    /// The lease value captured for <see cref="Owner"/> when tracking started.
+    /// </summary>
     public int OwnerLease { get; private set; }
 
+    /// <summary>
+    /// Gets a value indicating whether the owner is still valid for the captured lease.
+    /// </summary>
     public bool IsOwnerValid => Owner != null && Owner.IsStillValid(OwnerLease);
+
+    /// <summary>
+    /// Gets a value indicating whether the recyclable is still valid for the captured lease.
+    /// </summary>
     public bool IsRecyclableValid => Recyclable != null && Recyclable.IsStillValid(RecyclableLease);
 
     private LeaseState() { }
 
+    /// <summary>
+    /// Creates and initializes a lease state for the specified owner/recyclable pair.
+    /// </summary>
+    /// <param name="owner">The owning object.</param>
+    /// <param name="recyclable">The recyclable instance.</param>
+    /// <returns>The created lease state.</returns>
     public static LeaseState<TOwner, TRecyclable> Create(TOwner owner, TRecyclable recyclable)
     {
         var ret = pool.Value.Rent();
@@ -38,9 +89,19 @@ public class LeaseState<TOwner, TRecyclable> : Recyclable where TRecyclable : Re
         return ret;
     }
 
+    /// <summary>
+    /// Attempts to dispose the tracked recyclable using the captured lease.
+    /// </summary>
     public void TryDisposeRecyclable() => Recyclable?.TryDispose(RecyclableLease);
+
+    /// <summary>
+    /// Attempts to dispose the tracked owner using the captured lease.
+    /// </summary>
     public void TryDisposeOwner() => Owner?.TryDispose(OwnerLease);
 
+    /// <summary>
+    /// Clears tracked values when the state object is returned to the pool.
+    /// </summary>
     protected override void OnReturn()
     {
         base.OnReturn();
@@ -51,16 +112,36 @@ public class LeaseState<TOwner, TRecyclable> : Recyclable where TRecyclable : Re
     }
 }
 
+/// <summary>
+/// Represents a snapshot of the lease for a single recyclable object.
+/// </summary>
+/// <typeparam name="TRecyclable">The type being tracked.</typeparam>
 public class LeaseState<TRecyclable> : Recyclable where TRecyclable : Recyclable
 {
     private static LazyPool<LeaseState<TRecyclable>> pool = new LazyPool<LeaseState<TRecyclable>>(() => new LeaseState<TRecyclable>());
 
+    /// <summary>
+    /// The recyclable instance being tracked.
+    /// </summary>
     public TRecyclable? Recyclable { get; private set; }
+
+    /// <summary>
+    /// The lease value captured when tracking started.
+    /// </summary>
     public int RecyclableLease { get; private set; }
+
+    /// <summary>
+    /// Gets a value indicating whether the recyclable is still valid for the captured lease.
+    /// </summary>
     public bool IsRecyclableValid => Recyclable != null && Recyclable.IsStillValid(RecyclableLease);
 
     private LeaseState() { }
 
+    /// <summary>
+    /// Creates and initializes a lease state for the given recyclable.
+    /// </summary>
+    /// <param name="recyclable">The recyclable to track.</param>
+    /// <returns>The created lease state.</returns>
     public static LeaseState<TRecyclable> Create(TRecyclable recyclable)
     {
         var ret = pool.Value.Rent();
@@ -69,8 +150,14 @@ public class LeaseState<TRecyclable> : Recyclable where TRecyclable : Recyclable
         return ret;
     }
 
+    /// <summary>
+    /// Attempts to dispose the tracked recyclable using the captured lease.
+    /// </summary>
     public void TryDisposeRecyclable() => Recyclable?.TryDispose(RecyclableLease);
 
+    /// <summary>
+    /// Clears tracked values when this state object is returned to the pool.
+    /// </summary>
     protected override void OnReturn()
     {
         base.OnReturn();

--- a/src/tests/Observability/LeaseHelperTests.cs
+++ b/src/tests/Observability/LeaseHelperTests.cs
@@ -1,0 +1,78 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace klooie.tests;
+
+[TestClass]
+[TestCategory(Categories.Observability)]
+public class LeaseHelperTests
+{
+    [TestMethod]
+    public void TrackOwnerRelationship_DetectsDisposal()
+    {
+        var owner = DefaultRecyclablePool.Instance.Rent();
+        var child = DefaultRecyclablePool.Instance.Rent();
+
+        var state = LeaseHelper.TrackOwnerRelationship(owner, child);
+        try
+        {
+            Assert.IsTrue(state.IsOwnerValid);
+            Assert.IsTrue(state.IsRecyclableValid);
+
+            owner.Dispose();
+            Assert.IsFalse(state.IsOwnerValid);
+            Assert.IsTrue(state.IsRecyclableValid);
+
+            child.Dispose();
+            Assert.IsFalse(state.IsRecyclableValid);
+        }
+        finally
+        {
+            state.Dispose();
+            owner.TryDispose();
+            child.TryDispose();
+        }
+    }
+
+    [TestMethod]
+    public void TryDisposeMethods_DisposeTrackedObjects()
+    {
+        var owner = DefaultRecyclablePool.Instance.Rent();
+        var child = DefaultRecyclablePool.Instance.Rent();
+        var state = LeaseHelper.TrackOwnerRelationship(owner, child);
+
+        var ownerLease = owner.Lease;
+        var childLease = child.Lease;
+
+        try
+        {
+            state.TryDisposeRecyclable();
+            Assert.IsFalse(child.IsStillValid(childLease));
+
+            state.TryDisposeOwner();
+            Assert.IsFalse(owner.IsStillValid(ownerLease));
+        }
+        finally
+        {
+            state.Dispose();
+        }
+    }
+
+    [TestMethod]
+    public void Track_LeaseSnapshot_RemainsInvalidAfterReuse()
+    {
+        var item = DefaultRecyclablePool.Instance.Rent();
+        var state = LeaseHelper.Track(item);
+        var originalLease = item.Lease;
+
+        item.Dispose();
+        var rerented = DefaultRecyclablePool.Instance.Rent();
+        var newLease = rerented.Lease;
+
+        Assert.AreSame(item, rerented);
+        Assert.AreNotEqual(originalLease, newLease);
+        Assert.IsFalse(state.IsRecyclableValid);
+
+        rerented.Dispose();
+        state.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary
- document LeaseHelper and related classes with XML comments
- add LeaseHelper tests covering owner relationships and disposal logic

## Testing
- `dotnet test src/tests/tests.csproj -c Release -v minimal` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68516f881a98832580228f9174c29eb4