### PR TITLE
Implement Camera animation state to avoid lambda allocation

### DIFF
--- a/src/klooie/Animation/Animator.cs
+++ b/src/klooie/Animation/Animator.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Threading.Tasks;
+using klooie.Gaming;
 namespace klooie;
 
 /// <summary>
@@ -26,6 +27,12 @@ public static partial class Animator
         => AnimateAsync(ConsoleControlAnimationState.Create(control, destination, duration, easingFunction, delayProvider, autoReverse, autoReverseDelay, loop, animationLifetime, targetFramesPerSecond));
     public static void AnimateSync(this ConsoleControl control, Func<RectF> destination, double duration = 500, EasingFunction easingFunction = null, IDelayProvider delayProvider = null, bool autoReverse = false, float autoReverseDelay = 0, ILifetime? loop = null, ILifetime? animationLifetime = null, int targetFramesPerSecond = Animator.DeafultTargetFramesPerSecond)
      => AnimateSync(ConsoleControlAnimationState.Create(control, destination, duration, easingFunction, delayProvider, autoReverse, autoReverseDelay, loop, animationLifetime, targetFramesPerSecond));
+
+    public static Task AnimateAsync(this Camera camera, LocF destination, double duration = 500, EasingFunction easingFunction = null, IDelayProvider delayProvider = null, bool autoReverse = false, float autoReverseDelay = 0, ILifetime? loop = null, ILifetime? animationLifetime = null, int targetFramesPerSecond = Animator.DeafultTargetFramesPerSecond)
+        => AnimateAsync(CameraAnimationState.Create(camera, destination, duration, easingFunction, delayProvider, autoReverse, autoReverseDelay, loop, animationLifetime, targetFramesPerSecond));
+
+    public static void AnimateSync(this Camera camera, LocF destination, double duration = 500, EasingFunction easingFunction = null, IDelayProvider delayProvider = null, bool autoReverse = false, float autoReverseDelay = 0, ILifetime? loop = null, ILifetime? animationLifetime = null, int targetFramesPerSecond = Animator.DeafultTargetFramesPerSecond)
+        => AnimateSync(CameraAnimationState.Create(camera, destination, duration, easingFunction, delayProvider, autoReverse, autoReverseDelay, loop, animationLifetime, targetFramesPerSecond));
 
     public static Task AnimateAsync(this RGB from, RGB to, double duration, Action<RGB> onColorChanged, EasingFunction easingFunction = null, IDelayProvider delayProvider = null, bool autoReverse = false, float autoReverseDelay = 0, ILifetime? loop = null, ILifetime? animationLifetime = null, int targetFramesPerSecond = Animator.DeafultTargetFramesPerSecond)
         => AnimateAsync(RGBAnimationState.Create(from, to, duration, onColorChanged, easingFunction, delayProvider, autoReverse, autoReverseDelay, loop, animationLifetime, targetFramesPerSecond));

--- a/src/klooie/Animation/CameraAnimationState.cs
+++ b/src/klooie/Animation/CameraAnimationState.cs
@@ -1,0 +1,50 @@
+using klooie.Gaming;
+
+namespace klooie;
+
+public static partial class Animator
+{
+    private sealed class CameraAnimationState : FloatAnimationState<CameraAnimationState>
+    {
+        public Camera Camera { get; set; }
+        public LocF Destination { get; set; }
+        public float StartX { get; set; }
+        public float StartY { get; set; }
+
+        private static LazyPool<CameraAnimationState> pool = new LazyPool<CameraAnimationState>(() => new CameraAnimationState());
+
+        public static CameraAnimationState Create(Camera camera, LocF destination, double duration, EasingFunction easingFunction, IDelayProvider delayProvider, bool autoReverse, float autoReverseDelay, ILifetime? loop, ILifetime? animationLifetime, int targetFramesPerSecond)
+        {
+            var ret = pool.Value.Rent();
+            ret.Construct(camera, destination, duration, easingFunction, delayProvider, autoReverse, autoReverseDelay, loop, animationLifetime, targetFramesPerSecond);
+            return ret;
+        }
+
+        protected void Construct(Camera camera, LocF destination, double duration, EasingFunction easingFunction, IDelayProvider delayProvider, bool autoReverse, float autoReverseDelay, ILifetime? loop, ILifetime? animationLifetime, int targetFramesPerSecond)
+        {
+            base.Construct(0, 1, duration, this, SetLocation, easingFunction, delayProvider, autoReverse, autoReverseDelay, loop, animationLifetime, targetFramesPerSecond);
+            Camera = camera ?? throw new ArgumentNullException(nameof(camera));
+            Destination = destination;
+            StartX = camera.CameraLocation.Left;
+            StartY = camera.CameraLocation.Top;
+        }
+
+        private static void SetLocation(CameraAnimationState state, float v)
+        {
+            var xDelta = state.Destination.Left - state.StartX;
+            var yDelta = state.Destination.Top - state.StartY;
+            var frameX = state.StartX + (v * xDelta);
+            var frameY = state.StartY + (v * yDelta);
+            state.Camera.CameraLocation = new LocF(frameX, frameY);
+        }
+
+        protected override void OnReturn()
+        {
+            base.OnReturn();
+            Camera = null;
+            Destination = default;
+            StartX = 0;
+            StartY = 0;
+        }
+    }
+}

--- a/src/klooie/Gaming/Camera/Camera.cs
+++ b/src/klooie/Gaming/Camera/Camera.cs
@@ -101,26 +101,8 @@ public sealed partial class Camera : ConsolePanel
     /// <returns>an async task that completes when the animation is finished or cancelled</returns>
     public Task AnimateTo(LocF dest, float duration = 1000, EasingFunction ease = null, ILifetime lt = null, IDelayProvider delayProvider = null)
     {
-        // TODO: Go to the Animation folder and add a new file called CameraAnimationState.cs. It should follow the pattern that ConsoleControlAnimationState follows.
-        // Then expose an Animate API in Animator.cs that uses CameraAnimationState to animate the camera. Then this method won't need this setter function, which currently
-        // allocates an action on every call.
         ease = ease ?? EasingFunctions.EaseInOut;
-        var startX = cameraLocation.Left;
-        var startY = cameraLocation.Top;
-        var lease = lt?.Lease;
-        Action<float> setter = v =>
-        {
-            var xDelta = dest.Left - startX;
-            var yDelta = dest.Top - startY;
-            var frameX = startX + (v * xDelta);
-            var frameY = startY + (v * yDelta);
-            if (lt == null || (lt != null && lt.IsStillValid(lease.Value) == true))
-            {
-                CameraLocation = new LocF(frameX, frameY);
-            }
-        };
-
-        return Animator.AnimateAsync(0, 1, duration, setter, ease, delayProvider, false, 0, animationLifetime: lt); 
+        return Animator.AnimateAsync(this, dest, duration, ease, delayProvider, animationLifetime: lt);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- add `CameraAnimationState` to support camera animations without allocations
- expose `Animator` helpers for animating `Camera` instances
- refactor `Camera.AnimateTo` to use the new API

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851b6c26a4c8325bb2baa73a7b1148a