### PR TITLE
Implement FrameTaskScheduler and integrate Vision scanning

### DIFF
--- a/src/klooie/Containers/LayoutRootPanel.cs
+++ b/src/klooie/Containers/LayoutRootPanel.cs
@@ -2,6 +2,7 @@
 
 public partial class LayoutRootPanel : ConsolePanel
 {
+    public const int MaxPaintRate = Animator.DeafultTargetFramesPerSecond * 3;
     private Event _onWindowResized, _afterPaint;
     private int lastConsoleWidth, lastConsoleHeight;
     private List<TaskCompletionSource> paintRequests;
@@ -33,7 +34,7 @@ public partial class LayoutRootPanel : ConsolePanel
         lastConsoleHeight = ConsoleProvider.Current.WindowHeight - 1;
         ResizeTo(lastConsoleWidth, lastConsoleHeight);
         ConsoleApp.Current!.EndOfCycle.Subscribe(DebounceResize, this);
-        ConsoleApp.Current.EndOfCycle.SubscribeThrottled(DrainPaints, this, Animator.DeafultTargetFramesPerSecond * 3);
+        ConsoleApp.Current.EndOfCycle.SubscribeThrottled(DrainPaints, this, MaxPaintRate);
         DescendentAdded.Subscribe(OnDescendentAdded, this);
         OnDisposed(RestoreConsoleState);
         FocusStackDepth = 1;

--- a/src/klooie/Gaming/Helpers/FrameTaskScheduler.cs
+++ b/src/klooie/Gaming/Helpers/FrameTaskScheduler.cs
@@ -3,6 +3,8 @@ namespace klooie.Gaming;
 
 public class FrameTaskScheduler : Recyclable
 {
+    private Event<IFrameTask>? _taskIsLate;
+    public Event<IFrameTask> TaskIsLate => _taskIsLate ??= Event<IFrameTask>.Create();
     public const int IdealFrameRate = 50;
 
     private RecyclableList<LeaseState<Recyclable>> queue;
@@ -66,7 +68,7 @@ public class FrameTaskScheduler : Recyclable
                 var now = Game.Current.MainColliderGroup.Now;
                 if (now - task.LastExecutionTime > TimeSpan.FromMilliseconds(Frequency))
                 {
-                    TaskIsLate(task);
+                    _taskIsLate?.Fire(task);
                 }
                 FrameDebugger.RegisterTask(task.Name);
                 task.Execute();
@@ -80,7 +82,6 @@ public class FrameTaskScheduler : Recyclable
         }
     }
 
-    protected virtual void TaskIsLate(IFrameTask task) { }
 
     protected override void OnReturn()
     {

--- a/src/klooie/Gaming/Helpers/FrameTaskScheduler.cs
+++ b/src/klooie/Gaming/Helpers/FrameTaskScheduler.cs
@@ -1,0 +1,118 @@
+using System;
+namespace klooie.Gaming;
+
+public class FrameTaskScheduler : Recyclable
+{
+    public const int IdealFrameRate = 50;
+
+    private RecyclableList<LeaseState<Recyclable>> queue;
+    private double delayMs;
+    private double framesPerCycle;
+
+    public float Frequency { get; private set; }
+
+    private static LazyPool<FrameTaskScheduler> pool = new LazyPool<FrameTaskScheduler>(() => new FrameTaskScheduler());
+
+    private FrameTaskScheduler() { }
+
+    public static FrameTaskScheduler Create(float frequency)
+    {
+        var sched = pool.Value.Rent();
+        sched.Init(frequency);
+        return sched;
+    }
+
+    private void Init(float frequency)
+    {
+        Frequency = frequency;
+        queue = RecyclableListPool<LeaseState<Recyclable>>.Instance.Rent();
+        CalculateTiming();
+        Game.Current.InnerLoopAPIs.DelayIfValid(delayMs, FrameTaskSchedulerState.Create(this), LoopBody);
+    }
+
+    public void Enqueue(IFrameTask task)
+    {
+        queue.Items.Add(LeaseHelper.Track((Recyclable)task));
+    }
+
+    private void CalculateTiming()
+    {
+        delayMs = 1000.0 / IdealFrameRate;
+        if (Frequency < delayMs)
+        {
+            throw new ArgumentException("Frequency cannot be faster than the configured frame rate");
+        }
+        framesPerCycle = Math.Max(1, Frequency / delayMs);
+    }
+
+    private static void LoopBody(object obj)
+    {
+        var state = (FrameTaskSchedulerState)obj;
+        state.Scheduler.Process();
+        Game.Current.InnerLoopAPIs.DelayIfValid(state.Scheduler.delayMs, state, LoopBody);
+    }
+
+    private void Process()
+    {
+        if (queue.Count == 0) return;
+        int tasksPerTick = Math.Max(1, (int)Math.Ceiling(queue.Count / framesPerCycle));
+        for (int i = 0; i < tasksPerTick && queue.Count > 0; i++)
+        {
+            var lease = queue[0];
+            queue.Items.RemoveAt(0);
+            if (lease.IsRecyclableValid)
+            {
+                var task = (IFrameTask)lease.Recyclable!;
+                var now = Game.Current.MainColliderGroup.Now;
+                if (now - task.LastExecutionTime > TimeSpan.FromMilliseconds(Frequency))
+                {
+                    TaskIsLate(task);
+                }
+                FrameDebugger.RegisterTask(task.Name);
+                task.Execute();
+                task.LastExecutionTime = now;
+                queue.Items.Add(lease);
+            }
+            else
+            {
+                lease.TryDispose();
+            }
+        }
+    }
+
+    protected virtual void TaskIsLate(IFrameTask task) { }
+
+    protected override void OnReturn()
+    {
+        base.OnReturn();
+        if (queue != null)
+        {
+            for (int i = 0; i < queue.Count; i++)
+            {
+                queue[i].TryDispose();
+            }
+            queue.Dispose();
+            queue = null;
+        }
+    }
+}
+
+public class FrameTaskSchedulerState : DelayState
+{
+    public FrameTaskScheduler Scheduler { get; private set; }
+
+    public static FrameTaskSchedulerState Create(FrameTaskScheduler scheduler)
+    {
+        var state = FrameTaskSchedulerStatePool.Instance.Rent();
+        state.Scheduler = scheduler;
+        state.AddDependency(scheduler);
+        return state;
+    }
+
+    protected override void OnReturn()
+    {
+        base.OnReturn();
+        Scheduler = null!;
+    }
+}
+

--- a/src/klooie/Gaming/Helpers/IFrameTask.cs
+++ b/src/klooie/Gaming/Helpers/IFrameTask.cs
@@ -1,0 +1,8 @@
+namespace klooie.Gaming;
+
+public interface IFrameTask : ILifetime
+{
+    string Name { get; }
+    TimeSpan LastExecutionTime { get; set; }
+    void Execute();
+}

--- a/src/klooie/Gaming/Physics/Vision.cs
+++ b/src/klooie/Gaming/Physics/Vision.cs
@@ -1,12 +1,24 @@
 ﻿using System.Runtime.CompilerServices;
 
 namespace klooie.Gaming;
-public class Vision : Recyclable
+public class Vision : Recyclable, IFrameTask
 {
     public const float DefaultRange = 20;
     public const float DefaultAngularVisibility = 60;
     private static Event<Vision>? _visionInitiated;
     public static Event<Vision> VisionInitiated => _visionInitiated ??= Event<Vision>.Create();
+    private static FrameTaskScheduler? Scheduler;
+
+    private static void EnsureScheduler()
+    {
+        if (Scheduler != null) return;
+        Scheduler = FrameTaskScheduler.Create(667f);
+        ConsoleApp.Current.OnDisposed(static () =>
+        {
+            Scheduler?.TryDispose();
+            Scheduler = null;
+        });
+    }
 
 
     private Event? _visibleObjectsChanged;
@@ -21,17 +33,15 @@ public class Vision : Recyclable
     public GameCollider Eye { get; private set; } = null!;
     public float Range { get; set; } 
     public float AngularVisibility { get; set; } 
-    public float ScanOffset { get; set; }
     public CastingMode CastingMode { get; set; }
     public float AutoScanFrequency { get; set; }
     public float AngleStep {get;set;}
     public int AngleFuzz { get; set; }
     public  TimeSpan MaxMemoryTime { get; set; }
+    public TimeSpan LastExecutionTime { get; set; }
     public Vision() { }
 
     private static Random random = new Random();
-    private static int NextScanOffsetBase = 0;
-    private const int MinScanSpacing = 30; // ms (set as desired)
     public static Vision Create(GameCollider eye, bool autoScan = true)
     {
         var vision = VisionPool.Instance.Rent();
@@ -39,14 +49,14 @@ public class Vision : Recyclable
         vision.AutoScanFrequency = 667f;
         vision.AngleStep = 5;
         vision.AngleFuzz = 2;
-        vision.ScanOffset = (NextScanOffsetBase++ * MinScanSpacing) % vision.AutoScanFrequency;
         vision.CastingMode = CastingMode.SingleRay;
         vision.MaxMemoryTime = TimeSpan.FromSeconds(2);
         _visionInitiated?.Fire(vision);
 
         if (autoScan)
         {
-            Game.Current.InnerLoopAPIs.DelayIfValid(vision.ScanOffset, VisionDependencyState.Create(vision), ScanLoopBody);
+            EnsureScheduler();
+            Scheduler!.Enqueue(vision);
         }
         return vision;
     }
@@ -60,15 +70,6 @@ public class Vision : Recyclable
 
     public Angle FieldOfViewStart => Eye.Velocity.Angle.Add(-AngularVisibility / 2f);
     public Angle FieldOfViewEnd => Eye.Velocity.Angle.Add(AngularVisibility / 2f);
-
-    [method: MethodImpl(MethodImplOptions.NoInlining)]
-    private static void ScanLoopBody(object obj)
-    {
-        var state = (VisionDependencyState)obj;
-        FrameDebugger.RegisterTask(nameof(Vision));
-        state.Vision.Scan();
-        Game.Current.InnerLoopAPIs.DelayIfValid(state.Vision.AutoScanFrequency + state.Vision.ScanOffset, state, ScanLoopBody);
-    }
 
     [method: MethodImpl(MethodImplOptions.NoInlining)]
     public void Scan()
@@ -257,6 +258,9 @@ public class Vision : Recyclable
         }
     }
 
+    string IFrameTask.Name => nameof(Vision);
+    void IFrameTask.Execute() => Scan();
+
     [method: MethodImpl(MethodImplOptions.NoInlining)]
     private bool IsIgnoredByFilter(GameCollider potentialTarget)
     {
@@ -283,6 +287,7 @@ public class Vision : Recyclable
         TrackedObjectsList.Clear();
         _visibleObjectsChanged?.TryDispose();
         _visibleObjectsChanged = null;
+        LastExecutionTime = TimeSpan.Zero;
     }
 }
 

--- a/src/tests/Gaming/Movement/VisionTests.cs
+++ b/src/tests/Gaming/Movement/VisionTests.cs
@@ -24,7 +24,8 @@ public class VisionTests
     private static async Task SetupVisionTest(UITestManager context, RectF moverPosition)
     {
         var mover = Game.Current.GamePanel.Add(GameColliderPool.Instance.Rent());
-        var vision = Vision.Create(mover, autoScan: false);
+        var scheduler = FrameTaskScheduler.Create(1000);
+        var vision = Vision.Create(scheduler, mover, autoScan: false);
         vision.Range = 15;
    
         var visionFilter = new VisionFilter(vision);

--- a/src/tests/Gaming/Movement/WanderLogicTests.cs
+++ b/src/tests/Gaming/Movement/WanderLogicTests.cs
@@ -37,7 +37,8 @@ public class WanderLogicTests
     {
         Game.Current.GamePanel.Background = new RGB(50, 50, 50);
         var mover = AddMoverAndObstacles(moverPosition, curiosityPoint, obstaclePositions);
-        var vision = Vision.Create(mover, autoScan: false);
+        var scheduler = FrameTaskScheduler.Create(1000);
+        var vision = Vision.Create(scheduler, mover, autoScan: false);
         vision.Range = 15;
         vision.Scan();
         var visionFilter = new VisionFilter(vision);


### PR DESCRIPTION
## Summary
- revise FrameTaskScheduler to use LazyPool and LeaseHelper
- add scheduler lifecycle handling in Vision
- remove Vision scan offset logic

## Testing
- `dotnet test src/klooie.sln --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68598e7708ac83259045ec6dd8a9dafb