### PR TITLE
Enable generics in loop states

### DIFF
--- a/src/klooie/Animation/Animator.cs
+++ b/src/klooie/Animation/Animator.cs
@@ -88,9 +88,8 @@ public static partial class Animator
         ProcessAnimationFrame(frame);
     }
 
-    private static void ProcessAnimationFrame(object stateObj)
+    private static void ProcessAnimationFrame(AnimationFrameState frameState)
     {
-        var frameState = (AnimationFrameState)stateObj;
         if (frameState.I == frameState.NumberOfFrames - 1)
         {
             frameState.Dispose();

--- a/src/klooie/Animation/FloatAnimationState.cs
+++ b/src/klooie/Animation/FloatAnimationState.cs
@@ -57,9 +57,8 @@ public static partial  class Animator
             return state;
         }
 
-        private static void AfterForward(object o)
+        private static void AfterForward(FloatAnimationState state)
         {
-            var state = (FloatAnimationState)o;
             if (state.AutoReverse)
             {
                 if (state.AutoReverseDelay > 0)
@@ -77,18 +76,16 @@ public static partial  class Animator
             }
         }
 
-        private static void StartReverse(object o)
+        private static void StartReverse(FloatAnimationState state)
         {
-            var state = (FloatAnimationState)o;
             var temp = state.From;
             state.From = state.To;
             state.To = temp;
             AnimateInternal(state, AfterReverse);
         }
 
-        private static void AfterReverse(object o)
+        private static void AfterReverse(FloatAnimationState state)
         {
-            var state = (FloatAnimationState)o;
             if (state.AutoReverseDelay > 0)
             {
                 ConsoleApp.Current.InnerLoopAPIs.DelayIfValid(state.AutoReverseDelay, state, FinishReverse);
@@ -99,9 +96,8 @@ public static partial  class Animator
             }
         }
 
-        private static void FinishReverse(object o)
+        private static void FinishReverse(FloatAnimationState state)
         {
-            var state = (FloatAnimationState)o;
             state.From = state.OriginalFrom;
             state.To = state.OriginalTo;
             CompleteOrLoop(state);

--- a/src/klooie/Gaming/Movement/WanderDebugger.cs
+++ b/src/klooie/Gaming/Movement/WanderDebugger.cs
@@ -110,9 +110,8 @@ public class WanderDebugger : Wander
         Game.Current.InnerLoopAPIs.DelayIfValid(250, dependency, RemoveRunningLoopFilter);
     }
 
-    private static void RemoveRunningLoopFilter(object obj)
+    private static void RemoveRunningLoopFilter(DelayState state)
     {
-        var state = (DelayState)obj;
         var eye = (GameCollider)state.MainDependency;
         if (eye.Filters.Contains(LoopRunningFilter))
         {

--- a/src/klooie/Gaming/Physics/Vision.cs
+++ b/src/klooie/Gaming/Physics/Vision.cs
@@ -62,9 +62,8 @@ public class Vision : Recyclable
     public Angle FieldOfViewEnd => Eye.Velocity.Angle.Add(AngularVisibility / 2f);
 
     [method: MethodImpl(MethodImplOptions.NoInlining)]
-    private static void ScanLoopBody(object obj)
+    private static void ScanLoopBody(VisionDependencyState state)
     {
-        var state = (VisionDependencyState)obj;
         FrameDebugger.RegisterTask(nameof(Vision));
         state.Vision.Scan();
         Game.Current.InnerLoopAPIs.DelayIfValid(state.Vision.AutoScanFrequency + state.Vision.ScanOffset, state, ScanLoopBody);

--- a/src/tests/EventLoop/EventLoopTests.cs
+++ b/src/tests/EventLoop/EventLoopTests.cs
@@ -134,7 +134,7 @@ public class EventLoopTests
         var iters = 10;
         var delayMs = 10;
         var scope = new object();
-        loop.InnerLoopAPIs.Do(delayMs,scope, (s) => ++count == iters ? DoReturnType.Break : DoReturnType.Continue, s=> loop.Stop());
+        loop.InnerLoopAPIs.Do(delayMs, scope, (s) => ++count == iters ? DoReturnType.Break : DoReturnType.Continue, s => loop.Stop());
 
         var sw = Stopwatch.StartNew();
         loop.Run();
@@ -177,7 +177,7 @@ public class EventLoopTests
         var loop = new EventLoop();
         var obj = new object();
         var expectedDuration = 100;
-        loop.InnerLoopAPIs.Delay(expectedDuration,obj, o =>
+        loop.InnerLoopAPIs.Delay(expectedDuration, obj, o =>
         {
             Assert.AreSame(obj, o);
             loop.Stop();


### PR DESCRIPTION
## Summary
- introduce typed SynchronizedEvent for generic Invoke operations
- add ForLoopState<T> and DoLoopState<T> with pooling
- refactor InnerLoopAPIs to use typed loop states
- allow typed callbacks when invoking work in the next loop cycle

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68598b5093088325a831d7742f47d410