### PR TITLE
Add reusable synth patches and effects

### DIFF
--- a/src/klooie/Audio/Readme.md
+++ b/src/klooie/Audio/Readme.md
@@ -50,3 +50,21 @@ public class SoundSample : ConsoleApp
 }
 
 ```
+
+### Synthesizer patches and effects
+
+Klooie ships with several ready-made synthesizer patches that can be used when
+playing procedural music.  Each patch is a recyclable object so creating notes
+incurs almost no runtime allocation.  A patch can also be extended with effects
+that follow the same pattern.
+
+```csharp
+var lead = SynthPatches.CreateLead().WithTremolo();
+var pad  = SynthPatches.CreateRhythmicPad();
+var kick = SynthPatches.CreateKick();
+var snare = SynthPatches.CreateSnare();
+```
+
+Effects such as reverb, delay, stereo chorus, tremolo and a high pass filter can
+be chained via extension methods like `WithReverb()` or `WithHighPass()`.
+```

--- a/src/klooie/Audio/SignalProcessing/Effects/HighPassFilterEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/HighPassFilterEffect.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace klooie;
+public class HighPassFilterEffect : Recyclable, IEffect
+{
+    private float prevInput;
+    private float prevOutput;
+    private float alpha;
+
+    private static readonly LazyPool<HighPassFilterEffect> _pool = new(() => new HighPassFilterEffect());
+    protected HighPassFilterEffect() { }
+
+    public static HighPassFilterEffect Create(float cutoffHz = 200f, int sampleRate = SoundProvider.SampleRate)
+    {
+        var ret = _pool.Value.Rent();
+        ret.Construct(cutoffHz, sampleRate);
+        return ret;
+    }
+
+    protected void Construct(float cutoffHz, int sampleRate)
+    {
+        float dt = 1f / sampleRate;
+        float rc = 1f / (2f * MathF.PI * cutoffHz);
+        alpha = rc / (rc + dt);
+        prevInput = 0f;
+        prevOutput = 0f;
+    }
+
+    public float Process(float input, int frameIndex)
+    {
+        float output = alpha * (prevOutput + input - prevInput);
+        prevInput = input;
+        prevOutput = output;
+        return output;
+    }
+
+    protected override void OnReturn()
+    {
+        prevInput = 0f;
+        prevOutput = 0f;
+        alpha = 0f;
+        base.OnReturn();
+    }
+}

--- a/src/klooie/Audio/SignalProcessing/Effects/TremoloEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/TremoloEffect.cs
@@ -1,0 +1,46 @@
+using System;
+
+namespace klooie;
+public class TremoloEffect : Recyclable, IEffect
+{
+    private float depth;
+    private float rateHz;
+    private float phase;
+    private float sampleRate;
+
+    private static readonly LazyPool<TremoloEffect> _pool = new(() => new TremoloEffect());
+    protected TremoloEffect() { }
+
+    public static TremoloEffect Create(float depth = 0.5f, float rateHz = 5f, int sampleRate = SoundProvider.SampleRate)
+    {
+        var ret = _pool.Value.Rent();
+        ret.Construct(depth, rateHz, sampleRate);
+        return ret;
+    }
+
+    protected void Construct(float depth, float rateHz, int sampleRate)
+    {
+        this.depth = Math.Clamp(depth, 0f, 1f);
+        this.rateHz = rateHz;
+        this.phase = 0f;
+        this.sampleRate = sampleRate;
+    }
+
+    public float Process(float input, int frameIndex)
+    {
+        float mod = 1f - depth + depth * (0.5f * (MathF.Sin(phase) + 1f));
+        float output = input * mod;
+        phase += 2f * MathF.PI * rateHz / sampleRate;
+        if (phase > 2f * MathF.PI) phase -= 2f * MathF.PI;
+        return output;
+    }
+
+    protected override void OnReturn()
+    {
+        depth = 0f;
+        rateHz = 0f;
+        phase = 0f;
+        sampleRate = 0f;
+        base.OnReturn();
+    }
+}

--- a/src/klooie/Audio/SignalProcessing/SynthPatch.cs
+++ b/src/klooie/Audio/SignalProcessing/SynthPatch.cs
@@ -91,6 +91,12 @@ public static class SynthPatchExtensions
 
     public static SynthPatch WithChorus(this SynthPatch patch, int delayMs = 22, int depthMs = 7, float rateHz = 0.22f, float mix = 0.19f)
         => patch.WithEffect(StereoChorusEffect.Create(delayMs, depthMs, rateHz, mix));
+
+    public static SynthPatch WithTremolo(this SynthPatch patch, float depth = 0.5f, float rateHz = 5f)
+        => patch.WithEffect(TremoloEffect.Create(depth, rateHz));
+
+    public static SynthPatch WithHighPass(this SynthPatch patch, float cutoffHz = 200f)
+        => patch.WithEffect(HighPassFilterEffect.Create(cutoffHz));
 }
 
 public interface IEffect

--- a/src/klooie/Audio/SignalProcessing/SynthPatches.cs
+++ b/src/klooie/Audio/SignalProcessing/SynthPatches.cs
@@ -71,4 +71,82 @@ public static class SynthPatches
 
         return patch;
     }
+
+    public static SynthPatch CreateLead()
+    {
+        var patch = SynthPatch.Create();
+        patch.Waveform = WaveformType.Saw;
+        patch.EnablePitchDrift = true;
+        patch.DriftFrequencyHz = 0.2f;
+        patch.DriftAmountCents = 3f;
+        patch.EnableLowPassFilter = true;
+        patch.FilterAlpha = 0.03f;
+        patch.EnableDistortion = true;
+        patch.DistortionAmount = 0.3f;
+        patch.Envelope.Attack = 0.01;
+        patch.Envelope.Decay = 0.15;
+        patch.Envelope.Sustain = 0.6;
+        patch.Envelope.Release = 0.25;
+        patch.WithChorus();
+        patch.WithReverb();
+        return patch;
+    }
+
+    public static SynthPatch CreateKick()
+    {
+        var patch = SynthPatch.Create();
+        patch.Waveform = WaveformType.Sine;
+        patch.EnableTransient = true;
+        patch.TransientDurationSeconds = 0.005f;
+        patch.EnableDistortion = true;
+        patch.DistortionAmount = 0.3f;
+        patch.Envelope.Attack = 0.0;
+        patch.Envelope.Decay = 0.1;
+        patch.Envelope.Sustain = 0.0;
+        patch.Envelope.Release = 0.1;
+        patch.WithHighPass(20f);
+        return patch;
+    }
+
+    public static SynthPatch CreateSnare()
+    {
+        var patch = SynthPatch.Create();
+        patch.Waveform = WaveformType.Noise;
+        patch.EnableTransient = true;
+        patch.TransientDurationSeconds = 0.005f;
+        patch.EnableLowPassFilter = true;
+        patch.FilterAlpha = 0.2f;
+        patch.EnableDistortion = true;
+        patch.DistortionAmount = 0.4f;
+        patch.Envelope.Attack = 0.0;
+        patch.Envelope.Decay = 0.1;
+        patch.Envelope.Sustain = 0.0;
+        patch.Envelope.Release = 0.2;
+        patch.WithHighPass(1000f);
+        patch.WithReverb();
+        return patch;
+    }
+
+    public static SynthPatch CreateRhythmicPad()
+    {
+        var patch = SynthPatch.Create();
+        patch.Waveform = WaveformType.Saw;
+        patch.EnablePitchDrift = true;
+        patch.DriftFrequencyHz = 0.15f;
+        patch.DriftAmountCents = 5f;
+        patch.EnableSubOsc = true;
+        patch.SubOscLevel = 0.5f;
+        patch.SubOscOctaveOffset = -1;
+        patch.EnableLowPassFilter = true;
+        patch.FilterBaseAlpha = 0.015f;
+        patch.FilterMaxAlpha = 0.05f;
+        patch.EnableDynamicFilter = true;
+        patch.Envelope.Attack = 0.5;
+        patch.Envelope.Decay = 1.0;
+        patch.Envelope.Sustain = 0.75;
+        patch.Envelope.Release = 1.5;
+        patch.WithTremolo(depth: 0.5f, rateHz: 5f);
+        patch.WithReverb();
+        return patch;
+    }
 }


### PR DESCRIPTION
## Summary
- add high pass filter and tremolo audio effects
- expose convenience helpers `WithTremolo()` and `WithHighPass()`
- add production patches: lead, kick, snare and rhythmic pad
- document available patches and effects in the Audio README

## Testing
- `dotnet test -c Release -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c569f283883259560e10ccb6783d9