### PR TITLE
Centralize timeline playback and enhance controls

### DIFF
--- a/src/klooie/Audio/DAW/PianoWithTimeline.cs
+++ b/src/klooie/Audio/DAW/PianoWithTimeline.cs
@@ -11,12 +11,13 @@ public class PianoWithTimeline : ProtectedConsolePanel
     public PianoPanel Piano { get; private init; }
     public VirtualTimelineGrid Timeline { get; private init; }
     public StatusBar StatusBar { get; private init; }
-    public PianoWithTimeline(INoteSource notes, ConsoleControl? commandBar = null)
+    public TimelinePlayer Player => Timeline.Player;
+    public PianoWithTimeline(INoteSource notes, TimelinePlayer? player = null, ConsoleControl? commandBar = null)
     {
         var rowSpecPrefix = commandBar == null ? "1r" : "1p;1r";
         var rowOffset = commandBar == null ? 0 : 1;
         layout = ProtectedPanel.Add(new GridLayout($"{rowSpecPrefix};{StatusBar.Height}p", $"{PianoPanel.KeyWidth}p;1r")).Fill();
-        Timeline = layout.Add(new VirtualTimelineGrid(notes), 1, rowOffset); // col then row here - I know its strange
+        Timeline = layout.Add(new VirtualTimelineGrid(notes, player), 1, rowOffset); // col then row here - I know its strange
         Piano = layout.Add(new PianoPanel(Timeline.Viewport), 0, rowOffset);
         StatusBar = layout.Add(new StatusBar(), column: 0, row: rowOffset+1, columnSpan: 2);
     }

--- a/src/klooie/Audio/DAW/TimelinePlayer.cs
+++ b/src/klooie/Audio/DAW/TimelinePlayer.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Diagnostics;
+
+namespace klooie;
+
+/// <summary>
+/// Centralized controller that manages playback for a timeline.
+/// It exposes play, pause, stop and seeking functionality while
+/// raising an event whenever the playhead position changes.
+/// </summary>
+public class TimelinePlayer
+{
+    private readonly Func<double> maxBeatProvider;
+    private double playheadStartBeat;
+    private long? playbackStartTimestamp;
+
+    public bool StopAtEnd { get; set; } = true;
+    public bool IsPlaying { get; private set; }
+
+    /// <summary>
+    /// Beats per minute used to convert time to beats.
+    /// </summary>
+    public double BeatsPerMinute { get; set; }
+
+    /// <summary>
+    /// Current playhead position in beats.
+    /// </summary>
+    public double CurrentBeat { get; private set; }
+
+    private Event<double> beatChanged;
+    /// <summary>
+    /// Event fired whenever <see cref="CurrentBeat"/> changes.
+    /// </summary>
+    public Event<double> BeatChanged => beatChanged ??= Event<double>.Create();
+
+    public TimelinePlayer(Func<double> maxBeatProvider, double bpm)
+    {
+        this.maxBeatProvider = maxBeatProvider;
+        this.BeatsPerMinute = bpm;
+    }
+
+    public void Start(double startBeat = 0)
+    {
+        if (IsPlaying) return;
+        playheadStartBeat = startBeat;
+        CurrentBeat = startBeat;
+        playbackStartTimestamp = Stopwatch.GetTimestamp();
+        IsPlaying = true;
+        ScheduleTick();
+    }
+
+    public void Pause()
+    {
+        if (!IsPlaying) return;
+        UpdateCurrentBeat();
+        IsPlaying = false;
+        beatChanged?.Fire(CurrentBeat);
+    }
+
+    public void Resume()
+    {
+        if (IsPlaying) return;
+        playheadStartBeat = CurrentBeat;
+        playbackStartTimestamp = Stopwatch.GetTimestamp();
+        IsPlaying = true;
+        ScheduleTick();
+        beatChanged?.Fire(CurrentBeat);
+    }
+
+    public void Stop()
+    {
+        IsPlaying = false;
+        playbackStartTimestamp = null;
+        beatChanged?.Fire(CurrentBeat);
+    }
+
+    public void Seek(double beat)
+    {
+        CurrentBeat = Math.Max(0, beat);
+        playheadStartBeat = CurrentBeat;
+        playbackStartTimestamp = IsPlaying ? Stopwatch.GetTimestamp() : playbackStartTimestamp;
+        beatChanged?.Fire(CurrentBeat);
+    }
+
+    public void SeekBy(double deltaBeats) => Seek(CurrentBeat + deltaBeats);
+
+    private void ScheduleTick()
+    {
+        if (!IsPlaying) return;
+        ConsoleApp.Current.Scheduler.Delay(10, Tick);
+    }
+
+    private void Tick()
+    {
+        if (!IsPlaying) return;
+        UpdateCurrentBeat();
+        beatChanged?.Fire(CurrentBeat);
+        ScheduleTick();
+    }
+
+    private void UpdateCurrentBeat()
+    {
+        if (playbackStartTimestamp == null) return;
+        double elapsedSeconds = Stopwatch.GetElapsedTime(playbackStartTimestamp.Value).TotalSeconds;
+        var beat = playheadStartBeat + elapsedSeconds * BeatsPerMinute / 60.0;
+        var maxBeat = maxBeatProvider();
+        if (StopAtEnd && beat > maxBeat)
+        {
+            CurrentBeat = maxBeat;
+            Stop();
+        }
+        else
+        {
+            CurrentBeat = beat;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `TimelinePlayer` to drive all timeline playback
- refactor `VirtualTimelineGrid` to rely on the player and add seeking keys
- update `PianoWithTimeline` and `MelodyMaker` to share a `TimelinePlayer`
- expose pause/resume and seeking shortcuts

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68723f4ef8488325b2dec273cae7f135