### PR TITLE
Refactor effect interfaces to use context structs

### DIFF
--- a/src/klooie.Windows/AudioPlaybackEngine.cs
+++ b/src/klooie.Windows/AudioPlaybackEngine.cs
@@ -81,7 +81,7 @@ public abstract class AudioPlaybackEngine : ISoundProvider
         RecyclableList<SynthSignalSource> voices = RecyclableListPool<SynthSignalSource>.Instance.Rent(8);
         try
         {
-            patch.SpawnVoices(MIDIInput.MidiNoteToFrequency(note.MidiNote), MasterVolume, voices.Items);
+            patch.SpawnVoices(MIDIInput.MidiNoteToFrequency(note.MidiNote), MasterVolume, note, voices.Items);
             VoiceCountTracker.Track(voices.Items); 
             action(patch, voices);
         }

--- a/src/klooie/Audio/SignalProcessing/EffectContext.cs
+++ b/src/klooie/Audio/SignalProcessing/EffectContext.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace klooie;
+
+public struct EffectContext
+{
+    public float Input;
+    public int FrameIndex;
+    public float Time;
+    public NoteExpression Note;
+}
+
+public struct PitchModContext
+{
+    public float Time;
+    public float? ReleaseTime;
+    public NoteExpression Note;
+}

--- a/src/klooie/Audio/SignalProcessing/Effects/AggroDistortionEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/AggroDistortionEffect.cs
@@ -40,10 +40,10 @@ public sealed class AggroDistortionEffect : Recyclable, IEffect
     private const int oversample = 4;
     private readonly float lpAlpha = 1f - MathF.Exp(-2f * MathF.PI * 7000f / SoundProvider.SampleRate);
 
-    public float Process(float input, int frame, float time)
+    public float Process(in EffectContext ctx)
     {
         /* poly-phase 4× oversample ---------------------------------------- */
-        float s = input, outSum = 0f;
+        float s = ctx.Input, outSum = 0f;
         for (int p = 0; p < oversample; p++)
         {
             /* cheap linear upsample */

--- a/src/klooie/Audio/SignalProcessing/Effects/CabinetEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/CabinetEffect.cs
@@ -32,8 +32,9 @@ class CabinetEffect : Recyclable, IEffect
 
     public IEffect Clone() => Create();
 
-    public float Process(float x, int frame, float time)
+    public float Process(in EffectContext ctx)
     {
+        float x = ctx.Input;
         x = Biquad.Process(ref low, bl0, bl1, bl2, al1, al2, x);
         x = Biquad.Process(ref mid, bm0, bm1, bm2, am1, am2, x);
         x = Biquad.Process(ref high, bh0, bh1, bh2, ah1, ah2, x);

--- a/src/klooie/Audio/SignalProcessing/Effects/CompressorEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/CompressorEffect.cs
@@ -38,8 +38,9 @@ public sealed class CompressorEffect : Recyclable, IEffect
 
     public IEffect Clone() => Create(threshold, ratio, attack, release);
 
-    public float Process(float input, int frameIndex, float time)
+    public float Process(in EffectContext ctx)
     {
+        float input = ctx.Input;
         float level = MathF.Abs(input);
 
         /* envelope follower ------------------------------------------------*/

--- a/src/klooie/Audio/SignalProcessing/Effects/DCBlockerEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/DCBlockerEffect.cs
@@ -28,8 +28,9 @@ public sealed class DCBlockerEffect : Recyclable, IEffect
 
     public IEffect Clone() => Create();
 
-    public float Process(float x, int frame, float time)
+    public float Process(in EffectContext ctx)
     {
+        float x = ctx.Input;
         // y[n] = x[n] - x[n-1] + a * y[n-1]
         float y = x - xPrev + a * yPrev;
         xPrev = x;

--- a/src/klooie/Audio/SignalProcessing/Effects/DelayEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/DelayEffect.cs
@@ -33,8 +33,9 @@ public class DelayEffect : Recyclable, IEffect
         return ret;
     }
 
-    public float Process(float input, int frameIndex, float time)
+    public float Process(in EffectContext ctx)
     {
+        float input = ctx.Input;
         float delayed = buffer[pos];
         float output = (1 - mix) * input + mix * delayed;
         buffer[pos] = input + delayed * feedback;

--- a/src/klooie/Audio/SignalProcessing/Effects/DistortionEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/DistortionEffect.cs
@@ -43,9 +43,10 @@ class DistortionEffect : Recyclable, IEffect
 
     static float SoftClip(float x) => MathF.Tanh(x);
 
-    public float Process(float input, int frameIdx, float time)
+    public float Process(in EffectContext ctx)
     {
         // ---- 2× oversampling (linear) -------------------------------------
+        float input = ctx.Input;
         float mid = 0.5f * (input + prevIn);
         float a = Distort(prevIn);
         float b = Distort(mid);

--- a/src/klooie/Audio/SignalProcessing/Effects/EnvelopeEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/EnvelopeEffect.cs
@@ -31,9 +31,9 @@ public class EnvelopeEffect : Recyclable, IEffect
         Envelope.Sustain,
         Envelope.Release);
 
-    public float Process(float input, int frameIndex, float time)
+    public float Process(in EffectContext ctx)
     {
-        return input * Envelope.GetLevel(time);
+        return ctx.Input * Envelope.GetLevel(ctx.Time);
     }
 
     public void Release(float time) => Envelope.ReleaseNote(time);

--- a/src/klooie/Audio/SignalProcessing/Effects/Fade.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/Fade.cs
@@ -31,8 +31,10 @@ public class FadeInEffect : Recyclable, IEffect
 
     public IEffect Clone() => Create(fadeDuration);
 
-    public float Process(float input, int frameIndex, float time)
+    public float Process(in EffectContext ctx)
     {
+        float input = ctx.Input;
+        float time = ctx.Time;
         if (finished || fadeDuration <= 0)
             return input;
 
@@ -80,8 +82,10 @@ public class FadeOutEffect : Recyclable, IEffect
 
     public IEffect Clone() => Create(fadeDuration, fadeStartTime);
 
-    public float Process(float input, int frameIndex, float time)
+    public float Process(in EffectContext ctx)
     {
+        float input = ctx.Input;
+        float time = ctx.Time;
         if (finished || fadeDuration <= 0)
             return input;
 

--- a/src/klooie/Audio/SignalProcessing/Effects/HighPassFilterEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/HighPassFilterEffect.cs
@@ -30,8 +30,9 @@ public class HighPassFilterEffect : Recyclable, IEffect
 
     public IEffect Clone() => HighPassFilterEffect.Create(cutoffHz);
 
-    public float Process(float input, int frameIndex, float time)
+    public float Process(in EffectContext ctx)
     {
+        float input = ctx.Input;
         float output = alpha * (prevOutput + input - prevInput);
         prevInput = input;
         prevOutput = output;

--- a/src/klooie/Audio/SignalProcessing/Effects/LowPassFilterEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/LowPassFilterEffect.cs
@@ -24,8 +24,9 @@ class LowPassFilterEffect : Recyclable, IEffect
 
     public IEffect Clone() => LowPassFilterEffect.Create(alpha);
 
-    public float Process(float input, int frameIdx, float time)
+    public float Process(in EffectContext ctx)
     {
+        float input = ctx.Input;
         state += alpha * (input - state);
         return state;
     }

--- a/src/klooie/Audio/SignalProcessing/Effects/NoiseGateEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/NoiseGateEffect.cs
@@ -40,8 +40,9 @@ class NoiseGateEffect : Recyclable, IEffect
 
     public IEffect Clone() => NoiseGateEffect.Create(openThresh, closeThresh, attackMs, releaseMs);
 
-    public float Process(float input, int frame, float time)
+    public float Process(in EffectContext ctx)
     {
+        float input = ctx.Input;
         // write current sample into look-ahead ring
         lookBuf[lookPos] = input;
         int readPos = (lookPos + 1) & (lookBuf.Length - 1);

--- a/src/klooie/Audio/SignalProcessing/Effects/ParametricEQEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/ParametricEQEffect.cs
@@ -43,8 +43,8 @@ public class ParametricEQEffect : Recyclable, IEffect
         return fx;
     }
 
-    public float Process(float input, int frameIndex, float time)
-        => Biquad.Process(ref state, b0, b1, b2, a1, a2, input);
+    public float Process(in EffectContext ctx)
+        => Biquad.Process(ref state, b0, b1, b2, a1, a2, ctx.Input);
 
     public IEffect Clone()
         => Create(type, freq, gainDb, q);

--- a/src/klooie/Audio/SignalProcessing/Effects/PickTransientEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/PickTransientEffect.cs
@@ -31,8 +31,9 @@ public sealed class PickTransientEffect : Recyclable, IEffect
 
     public IEffect Clone() => Create(duration, gain);
 
-    public float Process(float x, int frame, float time)
+    public float Process(in EffectContext ctx)
     {
+        float x = ctx.Input;
         if (!active) return x;
 
         timeSinceOn += 1f / SoundProvider.SampleRate;

--- a/src/klooie/Audio/SignalProcessing/Effects/PingPongDelayEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/PingPongDelayEffect.cs
@@ -32,10 +32,11 @@ public class PingPongDelayEffect : Recyclable, IEffect
     }
 
     // Only processes mono (L+R alternation; true stereo can be more advanced)
-    public float Process(float input, int frameIndex, float time)
+    public float Process(in EffectContext ctx)
     {
+        float input = ctx.Input;
         // Simulate "frameIndex % 2" as L/R for stereo buffer writing
-        bool isLeft = (frameIndex & 1) == 0;
+        bool isLeft = (ctx.FrameIndex & 1) == 0;
 
         // Calculate read index (circular buffer)
         int readIndex = (writeIndex + 1) % bufferSize;

--- a/src/klooie/Audio/SignalProcessing/Effects/PitchBendEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/PitchBendEffect.cs
@@ -3,7 +3,7 @@ using System.Drawing;
 
 public interface IPitchModEffect : IEffect
 {
-    float GetPitchOffsetCents(float time, float? releaseTime); // <- note new arg
+    float GetPitchOffsetCents(in PitchModContext ctx);
 }
 
 
@@ -29,24 +29,24 @@ public class PitchBendEffect : Recyclable, IPitchModEffect
     }
 
     // The noteReleaseTime is nullable; if null, note is still held
-    public float GetPitchOffsetCents(float time, float? noteReleaseTime)
+    public float GetPitchOffsetCents(in PitchModContext ctx)
     {
-        if (noteReleaseTime == null || time < noteReleaseTime)
+        if (ctx.ReleaseTime == null || ctx.Time < ctx.ReleaseTime)
         {
             // attack/sustain phase
-            float t = Math.Min(time, attackDuration);
+            float t = Math.Min(ctx.Time, attackDuration);
             return attackBendFunc(t);
         }
         else
         {
             // release/decay phase
-            float tRelease = time - noteReleaseTime.Value;
+            float tRelease = ctx.Time - ctx.ReleaseTime.Value;
             float t = Math.Min(tRelease, releaseDuration);
             return releaseBendFunc(t);
         }
     }
 
-    public float Process(float input, int frameIndex, float time) => input;
+    public float Process(in EffectContext ctx) => ctx.Input;
 
     public IEffect Clone() => Create(attackBendFunc, attackDuration, releaseBendFunc, releaseDuration);
 

--- a/src/klooie/Audio/SignalProcessing/Effects/PresenceShelfEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/PresenceShelfEffect.cs
@@ -40,9 +40,10 @@ public sealed class PresenceShelfEffect : Recyclable, IEffect
     public IEffect Clone() => Create(20f * MathF.Log10(shelfGain));
 
     /* ----- core ---------------------------------------------------------- */
-    public float Process(float x, int frame, float time)
+    public float Process(in EffectContext ctx)
     {
         /* resonant LP ----------------------------------------------------- */
+        float x = ctx.Input;
         float y = b0 * x + b1 * resY1 + b2 * resY2 - a1 * resY1 - a2 * resY2;
         resY2 = resY1;
         resY1 = y;

--- a/src/klooie/Audio/SignalProcessing/Effects/ReverbEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/ReverbEffect.cs
@@ -126,8 +126,9 @@ public class ReverbEffect : Recyclable, IEffect
 
     public IEffect Clone() => Create(feedback, diffusion, wet, dry);
 
-    public float Process(float input, int frameIndex, float time)
+    public float Process(in EffectContext ctx)
     {
+        float input = ctx.Input;
         // Mix combs in parallel
         float combOut = 0f;
         for (int i = 0; i < combs.Length; i++)

--- a/src/klooie/Audio/SignalProcessing/Effects/StereoChorusEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/StereoChorusEffect.cs
@@ -39,20 +39,20 @@ public class StereoChorusEffect : Recyclable, IEffect
         phase = 0f;
     }
 
-    public float Process(float input, int frameIndex, float time)
+    public float Process(in EffectContext ctx)
     {
         // Mono version: pan modulation and width not shown; can be extended
         float mod = (float)Math.Sin(phase) * depthSamples;
         int readIndex = (int)((pos - delaySamples + mod + bufferL.Length) % bufferL.Length);
 
         float delayed = bufferL[readIndex];
-        bufferL[pos] = input;
+        bufferL[pos] = ctx.Input;
 
         pos = (pos + 1) % bufferL.Length;
         phase += 2 * MathF.PI * rateHz / SoundProvider.SampleRate;
         if (phase > 2 * MathF.PI) phase -= 2 * MathF.PI;
 
-        return (1 - mix) * input + mix * delayed;
+        return (1 - mix) * ctx.Input + mix * delayed;
     }
 
 

--- a/src/klooie/Audio/SignalProcessing/Effects/TiltEQEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/TiltEQEffect.cs
@@ -26,11 +26,12 @@ public sealed class TiltEQEffect : Recyclable, IEffect
 
     public IEffect Clone() => Create(tilt, alpha);
 
-    public float Process(float input, int frameIndex, float time)
+    public float Process(in EffectContext ctx)
     {
-        /* split ----------------------------------------------------------------*/
-        low += alpha * (input - low);          // 1-pole LP → “bass”
-        float high = input - low;              // residual  → “treble”
+        float input = ctx.Input;
+        /* split ---------------------------------------------------------------*/
+        low += alpha * (input - low);          // 1-pole LP -> "bass"
+        float high = input - low;              // residual  -> "treble"
 
         /* tilt mix --------------------------------------------------------------*/
         return low * (1f - tilt) +

--- a/src/klooie/Audio/SignalProcessing/Effects/ToneStackEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/ToneStackEffect.cs
@@ -39,8 +39,9 @@ public sealed class ToneStackEffect : Recyclable, IEffect
 
     public IEffect Clone() => Create(bassG, midG, trebG);
 
-    public float Process(float x, int frame, float time)
+    public float Process(in EffectContext ctx)
     {
+        float x = ctx.Input;
         /* low band --------------------------------------------------------- */
         lowLpf += alphaLow * (x - lowLpf);          // LPF @250 Hz
         float low = lowLpf;

--- a/src/klooie/Audio/SignalProcessing/Effects/TremoloEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/TremoloEffect.cs
@@ -26,10 +26,10 @@ public class TremoloEffect : Recyclable, IEffect
         this.phase = 0f;
     }
 
-    public float Process(float input, int frameIndex, float time)
+    public float Process(in EffectContext ctx)
     {
         float mod = 1f - depth + depth * (0.5f * (MathF.Sin(phase) + 1f));
-        float output = input * mod;
+        float output = ctx.Input * mod;
         phase += 2f * MathF.PI * rateHz / SoundProvider.SampleRate;
         if (phase > 2f * MathF.PI) phase -= 2f * MathF.PI;
         return output;

--- a/src/klooie/Audio/SignalProcessing/Effects/VolumeEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/VolumeEffect.cs
@@ -24,9 +24,9 @@ public class VolumeEffect : Recyclable, IEffect
         return Create(gain);
     }
 
-    public float Process(float input, int frameIdx, float time)
+    public float Process(in EffectContext ctx)
     {
-        return input * gain;
+        return ctx.Input * gain;
     }
 
     protected override void OnReturn()

--- a/src/klooie/Audio/SignalProcessing/Patches/AmpedRockGuitarPatch.cs
+++ b/src/klooie/Audio/SignalProcessing/Patches/AmpedRockGuitarPatch.cs
@@ -109,8 +109,9 @@ public sealed class AmpedRockGuitarPatch : Recyclable, ISynthPatch, ICompositePa
 
     public void SpawnVoices(float freq,
                             VolumeKnob master,
+                            NoteExpression note,
                             List<SynthSignalSource> outVoices)
-        => inner.SpawnVoices(freq, master, outVoices);
+        => inner.SpawnVoices(freq, master, note, outVoices);
 
     
     public void GetPatches(List<ISynthPatch> patches)

--- a/src/klooie/Audio/SignalProcessing/Patches/LayeredPatch.cs
+++ b/src/klooie/Audio/SignalProcessing/Patches/LayeredPatch.cs
@@ -81,6 +81,7 @@ public sealed class LayeredPatch : Recyclable, ISynthPatch, ICompositePatch
     public void SpawnVoices(
         float freq,
         VolumeKnob master,
+        NoteExpression note,
         List<SynthSignalSource> outVoices)
     {
         for (int i = 0; i < layers.Length; i++)
@@ -91,7 +92,7 @@ public sealed class LayeredPatch : Recyclable, ISynthPatch, ICompositePatch
                 ? freq
                 : freq * MathF.Pow(2f, layerTransposes[layerIdx] / 12f);
 
-            layers[layerIdx].SpawnVoices(transFreq, master, outVoices);
+            layers[layerIdx].SpawnVoices(transFreq, master, note, outVoices);
         }
     }
 

--- a/src/klooie/Audio/SignalProcessing/Patches/PowerChordPatch.cs
+++ b/src/klooie/Audio/SignalProcessing/Patches/PowerChordPatch.cs
@@ -112,7 +112,7 @@ public class PowerChordPatch : Recyclable, ISynthPatch, ICompositePatch
         }
     }
 
-    public void SpawnVoices(float frequencyHz, VolumeKnob master,  List<SynthSignalSource> outVoices)
+    public void SpawnVoices(float frequencyHz, VolumeKnob master, NoteExpression note,  List<SynthSignalSource> outVoices)
     {
         int numLayers = intervals.Length;
         for (int i = 0; i < numLayers; i++)
@@ -126,7 +126,7 @@ public class PowerChordPatch : Recyclable, ISynthPatch, ICompositePatch
 
             float freq = frequencyHz * MathF.Pow(2f, interval / 12.0f) * MathF.Pow(2f, detune / 1200.0f);
 
-            outVoices.Add(SynthSignalSource.Create(freq, (SynthPatch)patches[i], master));
+            outVoices.Add(SynthSignalSource.Create(freq, (SynthPatch)patches[i], master, note));
         }
     }
 

--- a/src/klooie/Audio/SignalProcessing/Patches/RockGuitar2.cs
+++ b/src/klooie/Audio/SignalProcessing/Patches/RockGuitar2.cs
@@ -101,8 +101,9 @@ public sealed class RockGuitar2 : Recyclable, ISynthPatch, ICompositePatch
 
     public void SpawnVoices(float freq,
                             VolumeKnob master,
+                            NoteExpression note,
                             List<SynthSignalSource> outVoices)
-        => inner.SpawnVoices(freq, master, outVoices);
+        => inner.SpawnVoices(freq, master, note, outVoices);
 
     protected override void OnReturn()
     {

--- a/src/klooie/Audio/SignalProcessing/Patches/SynthPatch.cs
+++ b/src/klooie/Audio/SignalProcessing/Patches/SynthPatch.cs
@@ -31,7 +31,7 @@ public interface ISynthPatch
 
     RecyclableList<IEffect> Effects { get; }
     ISynthPatch InnerPatch { get; }
-    void SpawnVoices(float frequencyHz, VolumeKnob master, List<SynthSignalSource> outVoices);
+    void SpawnVoices(float frequencyHz, VolumeKnob master, NoteExpression note, List<SynthSignalSource> outVoices);
 }
 
 public class SynthPatch : Recyclable, ISynthPatch
@@ -102,9 +102,9 @@ public class SynthPatch : Recyclable, ISynthPatch
         Effects = null!;
     }
 
-    public virtual void SpawnVoices(float frequencyHz, VolumeKnob master, List<SynthSignalSource> outVoices)
+    public virtual void SpawnVoices(float frequencyHz, VolumeKnob master, NoteExpression note, List<SynthSignalSource> outVoices)
     {
-        var innerVoice = SynthSignalSource.Create(frequencyHz, this, master);
+        var innerVoice = SynthSignalSource.Create(frequencyHz, this, master, note);
         this.OnDisposed(innerVoice, Recyclable.TryDisposeMe);
         outVoices.Add(innerVoice);
     }
@@ -419,7 +419,7 @@ public static class SynthPatchExtensions
 public interface IEffect
 {
     // Process a mono sample (or stereo, if you want!)
-    float Process(float input, int frameIndex, float time);
+    float Process(in EffectContext ctx);
     IEffect Clone();
 }
 

--- a/src/klooie/Audio/SignalProcessing/Patches/UnisonPatch.cs
+++ b/src/klooie/Audio/SignalProcessing/Patches/UnisonPatch.cs
@@ -109,6 +109,7 @@ public class UnisonPatch : Recyclable, ISynthPatch, ICompositePatch
     public void SpawnVoices(
         float frequencyHz,
         VolumeKnob master,
+        NoteExpression note,
         List<SynthSignalSource> outVoices)
     {
         for (int i = 0; i < numVoices; i++)
@@ -118,7 +119,7 @@ public class UnisonPatch : Recyclable, ISynthPatch, ICompositePatch
             float pan = rel * panSpread / Math.Max(numVoices - 1, 1);
             float detunedFreq = frequencyHz * MathF.Pow(2f, detune / 1200f);
 
-            outVoices.Add(SynthSignalSource.Create(detunedFreq, (SynthPatch)_innerPatches[i], master));
+            outVoices.Add(SynthSignalSource.Create(detunedFreq, (SynthPatch)_innerPatches[i], master, note));
         }
     }
 


### PR DESCRIPTION
## Summary
- add `EffectContext` and `PitchModContext` structs
- update `IEffect` and `IPitchModEffect` to consume the new contexts
- refactor all audio effect implementations to use the context
- update `SynthSignalSource` to reuse a context object and pass note info
- propagate context usage through patch classes and the audio engine

## Testing
- `dotnet test src/klooie.sln --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878223e11a88325b4333be60bf393ba