### PR TITLE
Implement velocity aware audio effects

### DIFF
--- a/src/klooie/Audio/SignalProcessing/EffectContext.cs
+++ b/src/klooie/Audio/SignalProcessing/EffectContext.cs
@@ -8,6 +8,24 @@ public struct EffectContext
     public int FrameIndex;
     public float Time;
     public NoteExpression Note;
+    public float VelocityNorm => Note.Velocity / 127f;
+
+    public static float EaseLinear(float t) => t;
+    public static float EaseInQuad(float t) => t * t;
+    public static float EaseOutQuad(float t) => t * (2 - t);
+    public static float EaseInOutQuad(float t) => t < 0.5f ? 2 * t * t : -1 + (4 - 2 * t) * t;
+    public static float EaseInCubic(float t) => t * t * t;
+    public static float EaseOutCubic(float t)
+    {
+        t -= 1f;
+        return t * t * t + 1f;
+    }
+    public static float EaseInOutCubic(float t)
+    {
+        return t < 0.5f
+            ? 4f * t * t * t
+            : (t - 1f) * (2f * t - 2f) * (2f * t - 2f) + 1f;
+    }
 }
 
 public struct PitchModContext

--- a/src/klooie/Audio/SignalProcessing/Effects/CompressorEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/CompressorEffect.cs
@@ -17,6 +17,9 @@ public sealed class CompressorEffect : Recyclable, IEffect
     /* --- state ---------------------------------------------------------- */
     private float envelope;
 
+    private Func<float, float> velocityCurve = EffectContext.EaseLinear;
+    private float velocityScale = 1f;
+
     /* --- pooling -------------------------------------------------------- */
     private static readonly LazyPool<CompressorEffect> _pool = new(() => new CompressorEffect());
     private CompressorEffect() { }
@@ -25,7 +28,9 @@ public sealed class CompressorEffect : Recyclable, IEffect
         float threshold = 0.6f,
         float ratio = 4f,
         float attack = 0.01f,
-        float release = 0.005f)
+        float release = 0.005f,
+        Func<float, float>? velocityCurve = null,
+        float velocityScale = 1f)
     {
         var fx = _pool.Value.Rent();
         fx.threshold = threshold;
@@ -33,14 +38,18 @@ public sealed class CompressorEffect : Recyclable, IEffect
         fx.attack = attack;
         fx.release = release;
         fx.envelope = 0f;
+        fx.velocityCurve = velocityCurve ?? EffectContext.EaseLinear;
+        fx.velocityScale = velocityScale;
         return fx;
     }
 
-    public IEffect Clone() => Create(threshold, ratio, attack, release);
+    public IEffect Clone() => Create(threshold, ratio, attack, release, velocityCurve, velocityScale);
 
     public float Process(in EffectContext ctx)
     {
         float input = ctx.Input;
+        float velFactor = velocityCurve(ctx.VelocityNorm) * velocityScale;
+        float thresholdMod = threshold * velFactor;
         float level = MathF.Abs(input);
 
         /* envelope follower ------------------------------------------------*/
@@ -50,10 +59,10 @@ public sealed class CompressorEffect : Recyclable, IEffect
 
         /* gain computer ----------------------------------------------------*/
         float gain = 1f;
-        if (envelope > threshold && envelope > 1e-9f)
+        if (envelope > thresholdMod && envelope > 1e-9f)
         {
-            float over = envelope - threshold;
-            float compressed = threshold + over / ratio;   // soft-knee-ish
+            float over = envelope - thresholdMod;
+            float compressed = thresholdMod + over / ratio;   // soft-knee-ish
             gain = compressed / envelope;
         }
 
@@ -63,6 +72,8 @@ public sealed class CompressorEffect : Recyclable, IEffect
     protected override void OnReturn()
     {
         threshold = ratio = attack = release = envelope = 0f;
+        velocityCurve = EffectContext.EaseLinear;
+        velocityScale = 1f;
         base.OnReturn();
     }
 }

--- a/src/klooie/Audio/SignalProcessing/Effects/LowPassFilterEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/LowPassFilterEffect.cs
@@ -10,15 +10,24 @@ class LowPassFilterEffect : Recyclable, IEffect
     private float alpha;
     private float state;
     private float cutoffHz;
+    private float mix = 1f;
+    private bool velocityAffectsMix;
+    private Func<float, float> mixVelocityCurve = EffectContext.EaseLinear;
 
     private static readonly LazyPool<LowPassFilterEffect> _pool = new(() => new LowPassFilterEffect());
 
     private LowPassFilterEffect() { }
 
-    public static LowPassFilterEffect Create(float cutoffHz = 200f)
+    public static LowPassFilterEffect Create(float cutoffHz = 200f,
+        float mix = 1f,
+        bool velocityAffectsMix = true,
+        Func<float, float>? mixVelocityCurve = null)
     {
         var fx = _pool.Value.Rent();
         fx.Construct(cutoffHz);
+        fx.mix = mix;
+        fx.velocityAffectsMix = velocityAffectsMix;
+        fx.mixVelocityCurve = mixVelocityCurve ?? EffectContext.EaseLinear;
         return fx;
     }
 
@@ -31,13 +40,17 @@ class LowPassFilterEffect : Recyclable, IEffect
         state = 0f;
     }
 
-    public IEffect Clone() => LowPassFilterEffect.Create(cutoffHz);
+    public IEffect Clone() => LowPassFilterEffect.Create(cutoffHz, mix, velocityAffectsMix, mixVelocityCurve);
 
     public float Process(in EffectContext ctx)
     {
         float input = ctx.Input;
         state += alpha * (input - state);
-        return state;
+        float wet = state;
+        float mixAmt = mix;
+        if (velocityAffectsMix)
+            mixAmt *= mixVelocityCurve(ctx.VelocityNorm);
+        return input * (1 - mixAmt) + wet * mixAmt;
     }
 
     protected override void OnReturn()
@@ -45,6 +58,9 @@ class LowPassFilterEffect : Recyclable, IEffect
         state = 0f;
         alpha = 0f;
         cutoffHz = 0f;
+        mix = 1f;
+        velocityAffectsMix = false;
+        mixVelocityCurve = EffectContext.EaseLinear;
         base.OnReturn();
     }
 }

--- a/src/klooie/Audio/SignalProcessing/Effects/PingPongDelayEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/PingPongDelayEffect.cs
@@ -5,6 +5,8 @@ public class PingPongDelayEffect : Recyclable, IEffect
     private float[] leftBuffer, rightBuffer;
     private int bufferSize, writeIndex;
     private float feedback, mix;
+    private bool velocityAffectsMix;
+    private Func<float, float> mixVelocityCurve = EffectContext.EaseLinear;
     private int delaySamples;
 
     private float prevLeftOut, prevRightOut;
@@ -13,12 +15,16 @@ public class PingPongDelayEffect : Recyclable, IEffect
 
     private PingPongDelayEffect() { }
 
-    public static PingPongDelayEffect Create(int delaySamples, float feedback = 0.5f, float mix = 0.4f)
+    public static PingPongDelayEffect Create(int delaySamples, float feedback = 0.5f, float mix = 0.4f,
+        bool velocityAffectsMix = true,
+        Func<float, float>? mixVelocityCurve = null)
     {
         var fx = _pool.Value.Rent();
         fx.delaySamples = delaySamples;
         fx.feedback = Math.Clamp(feedback, 0f, 0.98f);
         fx.mix = Math.Clamp(mix, 0f, 1f);
+        fx.velocityAffectsMix = velocityAffectsMix;
+        fx.mixVelocityCurve = mixVelocityCurve ?? EffectContext.EaseLinear;
 
         fx.bufferSize = Math.Max(2, delaySamples + 1);
         fx.leftBuffer = fx.leftBuffer != null && fx.leftBuffer.Length == fx.bufferSize ? fx.leftBuffer : new float[fx.bufferSize];
@@ -61,17 +67,21 @@ public class PingPongDelayEffect : Recyclable, IEffect
         if (!isLeft)
             writeIndex = (writeIndex + 1) % bufferSize;
 
-        // Simple mix: dry + wet
-        return dry * (1f - mix) + wet * mix;
+        float mixAmt = mix;
+        if (velocityAffectsMix)
+            mixAmt *= mixVelocityCurve(ctx.VelocityNorm);
+        return dry * (1f - mixAmt) + wet * mixAmt;
     }
 
-    public IEffect Clone() => Create(delaySamples, feedback, mix);
+    public IEffect Clone() => Create(delaySamples, feedback, mix, velocityAffectsMix, mixVelocityCurve);
 
     protected override void OnReturn()
     {
         leftBuffer = rightBuffer = null;
         bufferSize = writeIndex = 0;
         prevLeftOut = prevRightOut = 0f;
+        velocityAffectsMix = false;
+        mixVelocityCurve = EffectContext.EaseLinear;
         base.OnReturn();
     }
 }

--- a/src/klooie/Audio/SignalProcessing/Effects/VolumeEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/VolumeEffect.cs
@@ -5,33 +5,47 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace klooie;
+/// <summary>
+/// Scales the input by a constant gain and optionally modulates that gain with
+/// note velocity.
+/// </summary>
 public class VolumeEffect : Recyclable, IEffect
 {
-    float gain;
+    private float gain;
+    private Func<float, float> velocityCurve = EffectContext.EaseLinear;
+    private float velocityScale = 1f;
 
     private VolumeEffect() { }
     static readonly LazyPool<VolumeEffect> _pool = new(() => new VolumeEffect());
 
-    public static VolumeEffect Create(float gain = 1.0f)
+    public static VolumeEffect Create(
+        float gain = 1.0f,
+        Func<float, float>? velocityCurve = null,
+        float velocityScale = 1f)
     {
         var fx = _pool.Value.Rent();
         fx.gain = gain;
+        fx.velocityCurve = velocityCurve ?? EffectContext.EaseLinear;
+        fx.velocityScale = velocityScale;
         return fx;
     }
 
     public IEffect Clone()
     {
-        return Create(gain);
+        return Create(gain, velocityCurve, velocityScale);
     }
 
     public float Process(in EffectContext ctx)
     {
-        return ctx.Input * gain;
+        float vel = velocityCurve(ctx.VelocityNorm) * velocityScale;
+        return ctx.Input * gain * vel;
     }
 
     protected override void OnReturn()
     {
         gain = 1.0f;
+        velocityCurve = EffectContext.EaseLinear;
+        velocityScale = 1f;
         base.OnReturn();
     }
 }


### PR DESCRIPTION
## Summary
- extend `EffectContext` with velocity info and easing helpers
- support velocity modulation for mix or gain on various effects
- add optional curve parameters on creation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a4eab1754832582dabdbef043bdb8