### PR TITLE
Fix playhead starting at zero when playback starts mid timeline

### DIFF
--- a/src/klooie/Audio/DAW/Timeline/VirtualTimelineGrid.cs
+++ b/src/klooie/Audio/DAW/Timeline/VirtualTimelineGrid.cs
@@ -170,7 +170,11 @@ public class VirtualTimelineGrid : ProtectedConsolePanel
         {
             ConsoleApp.Current.Scheduler.Delay(60, () =>
             {
-                me.Player.Start(note.StartBeat);
+                // The incoming note's StartBeat is relative to the play request
+                // which may be zero if playback starts mid-timeline. Using it
+                // would reset the playhead to the beginning, so instead start
+                // at the current beat that playback was initiated from.
+                me.Player.Start(me.CurrentBeat);
                 me.PlaybackStarting.Fire(me.CurrentBeat);
             });
         });


### PR DESCRIPTION
## Summary
- keep the playhead at the requested beat when playback begins

## Testing
- `dotnet test src/tests/tests.csproj -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a55bc206c8325aa4096459b3250ba