### PR TITLE
Refactor all effects to use settings struct

### DIFF
--- a/src/klooie/Audio/SignalProcessing/Effects/AggroDistortionEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/AggroDistortionEffect.cs
@@ -23,25 +23,40 @@ public sealed class AggroDistortionEffect : Recyclable, IEffect
 
     private AggroDistortionEffect() { }
 
-    public static AggroDistortionEffect Create(
-        float drive = 12f,       // hotter than before
-        float stageRatio = 0.8f, // keep stages fairly hot
-        float bias = 0.12f,      // subtle even-harmonics
-        Func<float, float>? velocityCurve = null,
-        float velocityScale = 1f)
+    public struct Settings
+    {
+        public float Drive;
+        public float StageRatio;
+        public float Bias;
+        public Func<float, float>? VelocityCurve;
+        public float VelocityScale;
+    }
+
+    public static AggroDistortionEffect Create(in Settings settings)
     {
         var fx = _pool.Value.Rent();
-        fx.preGain = drive;
-        fx.stageRatio = stageRatio;
-        fx.bias = bias;
-        fx.makeup = 1f / MathF.Tanh(drive * 0.7f); // auto-level
+        fx.preGain = settings.Drive;
+        fx.stageRatio = settings.StageRatio;
+        fx.bias = settings.Bias;
+        fx.makeup = 1f / MathF.Tanh(settings.Drive * 0.7f); // auto-level
         fx.Reset();
-        fx.velocityCurve = velocityCurve ?? EffectContext.EaseLinear;
-        fx.velocityScale = velocityScale;
+        fx.velocityCurve = settings.VelocityCurve ?? EffectContext.EaseLinear;
+        fx.velocityScale = settings.VelocityScale;
         return fx;
     }
 
-    public IEffect Clone() => Create(preGain, stageRatio, bias, velocityCurve, velocityScale);
+    public IEffect Clone()
+    {
+        var settings = new Settings
+        {
+            Drive = preGain,
+            StageRatio = stageRatio,
+            Bias = bias,
+            VelocityCurve = velocityCurve,
+            VelocityScale = velocityScale
+        };
+        return Create(in settings);
+    }
 
     /* pre-compiled constants ---------------------------------------------- */
     private const int oversample = 4;

--- a/src/klooie/Audio/SignalProcessing/Effects/CompressorEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/CompressorEffect.cs
@@ -24,26 +24,42 @@ public sealed class CompressorEffect : Recyclable, IEffect
     private static readonly LazyPool<CompressorEffect> _pool = new(() => new CompressorEffect());
     private CompressorEffect() { }
 
-    public static CompressorEffect Create(
-        float threshold = 0.6f,
-        float ratio = 4f,
-        float attack = 0.01f,
-        float release = 0.005f,
-        Func<float, float>? velocityCurve = null,
-        float velocityScale = 1f)
+    public struct Settings
+    {
+        public float Threshold;
+        public float Ratio;
+        public float Attack;
+        public float Release;
+        public Func<float, float>? VelocityCurve;
+        public float VelocityScale;
+    }
+
+    public static CompressorEffect Create(in Settings settings)
     {
         var fx = _pool.Value.Rent();
-        fx.threshold = threshold;
-        fx.ratio = ratio;
-        fx.attack = attack;
-        fx.release = release;
+        fx.threshold = settings.Threshold;
+        fx.ratio = settings.Ratio;
+        fx.attack = settings.Attack;
+        fx.release = settings.Release;
         fx.envelope = 0f;
-        fx.velocityCurve = velocityCurve ?? EffectContext.EaseLinear;
-        fx.velocityScale = velocityScale;
+        fx.velocityCurve = settings.VelocityCurve ?? EffectContext.EaseLinear;
+        fx.velocityScale = settings.VelocityScale;
         return fx;
     }
 
-    public IEffect Clone() => Create(threshold, ratio, attack, release, velocityCurve, velocityScale);
+    public IEffect Clone()
+    {
+        var settings = new Settings
+        {
+            Threshold = threshold,
+            Ratio = ratio,
+            Attack = attack,
+            Release = release,
+            VelocityCurve = velocityCurve,
+            VelocityScale = velocityScale
+        };
+        return Create(in settings);
+    }
 
     public float Process(in EffectContext ctx)
     {

--- a/src/klooie/Audio/SignalProcessing/Effects/DCBlockerEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/DCBlockerEffect.cs
@@ -19,19 +19,32 @@ public sealed class DCBlockerEffect : Recyclable, IEffect
         new(() => new DCBlockerEffect());
     private DCBlockerEffect() { }
 
-    public static DCBlockerEffect Create(bool velocityAffectsOutput = false,
-        Func<float, float>? velocityCurve = null)
+    public struct Settings
+    {
+        public bool VelocityAffectsOutput;
+        public Func<float, float>? VelocityCurve;
+    }
+
+    public static DCBlockerEffect Create(in Settings settings)
     {
         var fx = _pool.Value.Rent();
         float sr = SoundProvider.SampleRate;
         fx.a = (float)Math.Exp(-2.0 * Math.PI * fCut / sr);
         fx.xPrev = fx.yPrev = 0f;
-        fx.velocityAffectsOutput = velocityAffectsOutput;
-        fx.velocityCurve = velocityCurve ?? EffectContext.EaseLinear;
+        fx.velocityAffectsOutput = settings.VelocityAffectsOutput;
+        fx.velocityCurve = settings.VelocityCurve ?? EffectContext.EaseLinear;
         return fx;
     }
 
-    public IEffect Clone() => Create(velocityAffectsOutput, velocityCurve);
+    public IEffect Clone()
+    {
+        var settings = new Settings
+        {
+            VelocityAffectsOutput = velocityAffectsOutput,
+            VelocityCurve = velocityCurve
+        };
+        return Create(in settings);
+    }
 
     public float Process(in EffectContext ctx)
     {

--- a/src/klooie/Audio/SignalProcessing/Effects/EnvelopeEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/EnvelopeEffect.cs
@@ -13,23 +13,37 @@ public class EnvelopeEffect : Recyclable, IEffect
 
     private EnvelopeEffect() { }
 
-    public static EnvelopeEffect Create(double attack, double decay, double sustain, double release)
+    public struct Settings
+    {
+        public double Attack;
+        public double Decay;
+        public double Sustain;
+        public double Release;
+    }
+
+    public static EnvelopeEffect Create(in Settings settings)
     {
         var fx = _pool.Value.Rent();
         fx.Envelope = ADSREnvelope.Create();
-        fx.Envelope.Attack = attack;
-        fx.Envelope.Decay = decay;
-        fx.Envelope.Sustain = sustain;
-        fx.Envelope.Release = release;
+        fx.Envelope.Attack = settings.Attack;
+        fx.Envelope.Decay = settings.Decay;
+        fx.Envelope.Sustain = settings.Sustain;
+        fx.Envelope.Release = settings.Release;
         fx.Envelope.Trigger(0, SoundProvider.SampleRate);
         return fx;
     }
 
-    public IEffect Clone() => Create(
-        Envelope.Attack,
-        Envelope.Decay,
-        Envelope.Sustain,
-        Envelope.Release);
+    public IEffect Clone()
+    {
+        var settings = new Settings
+        {
+            Attack = Envelope.Attack,
+            Decay = Envelope.Decay,
+            Sustain = Envelope.Sustain,
+            Release = Envelope.Release
+        };
+        return Create(in settings);
+    }
 
     public float Process(in EffectContext ctx)
     {

--- a/src/klooie/Audio/SignalProcessing/Effects/Fade.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/Fade.cs
@@ -18,14 +18,19 @@ public class FadeInEffect : Recyclable, IEffect
 
     private FadeInEffect() { }
 
-    public static FadeInEffect Create(float durationSeconds,
-        Func<float, float>? velocityCurve = null,
-        float velocityScale = 1f)
+    public struct Settings
+    {
+        public float DurationSeconds;
+        public Func<float, float>? VelocityCurve;
+        public float VelocityScale;
+    }
+
+    public static FadeInEffect Create(in Settings settings)
     {
         var ret = _pool.Value.Rent();
-        ret.Construct(durationSeconds);
-        ret.velocityCurve = velocityCurve ?? EffectContext.EaseLinear;
-        ret.velocityScale = velocityScale;
+        ret.Construct(settings.DurationSeconds);
+        ret.velocityCurve = settings.VelocityCurve ?? EffectContext.EaseLinear;
+        ret.velocityScale = settings.VelocityScale;
         return ret;
     }
 
@@ -35,7 +40,16 @@ public class FadeInEffect : Recyclable, IEffect
         finished = false;
     }
 
-    public IEffect Clone() => Create(fadeDuration, velocityCurve, velocityScale);
+    public IEffect Clone()
+    {
+        var settings = new Settings
+        {
+            DurationSeconds = fadeDuration,
+            VelocityCurve = velocityCurve,
+            VelocityScale = velocityScale
+        };
+        return Create(in settings);
+    }
 
     public float Process(in EffectContext ctx)
     {
@@ -77,14 +91,20 @@ public class FadeOutEffect : Recyclable, IEffect
     /// durationSeconds: how long the fade should last
     /// fadeStartTime: time (in seconds) when fade should *start* (default = 0 to fade from the beginning)
     /// </summary>
-    public static FadeOutEffect Create(float durationSeconds, float fadeStartTime = 0,
-        Func<float, float>? velocityCurve = null,
-        float velocityScale = 1f)
+public struct Settings
+{
+    public float DurationSeconds;
+    public float FadeStartTime;
+    public Func<float, float>? VelocityCurve;
+    public float VelocityScale;
+}
+
+    public static FadeOutEffect Create(in Settings settings)
     {
         var ret = _pool.Value.Rent();
-        ret.Construct(durationSeconds, fadeStartTime);
-        ret.velocityCurve = velocityCurve ?? EffectContext.EaseLinear;
-        ret.velocityScale = velocityScale;
+        ret.Construct(settings.DurationSeconds, settings.FadeStartTime);
+        ret.velocityCurve = settings.VelocityCurve ?? EffectContext.EaseLinear;
+        ret.velocityScale = settings.VelocityScale;
         return ret;
     }
 
@@ -95,7 +115,17 @@ public class FadeOutEffect : Recyclable, IEffect
         finished = false;
     }
 
-    public IEffect Clone() => Create(fadeDuration, fadeStartTime, velocityCurve, velocityScale);
+    public IEffect Clone()
+    {
+        var settings = new Settings
+        {
+            DurationSeconds = fadeDuration,
+            FadeStartTime = fadeStartTime,
+            VelocityCurve = velocityCurve,
+            VelocityScale = velocityScale
+        };
+        return Create(in settings);
+    }
 
     public float Process(in EffectContext ctx)
     {

--- a/src/klooie/Audio/SignalProcessing/Effects/HighPassFilterEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/HighPassFilterEffect.cs
@@ -14,16 +14,21 @@ public class HighPassFilterEffect : Recyclable, IEffect
     private static readonly LazyPool<HighPassFilterEffect> _pool = new(() => new HighPassFilterEffect());
     protected HighPassFilterEffect() { }
 
-    public static HighPassFilterEffect Create(float cutoffHz = 200f,
-        float mix = 1f,
-        bool velocityAffectsMix = true,
-        Func<float, float>? mixVelocityCurve = null)
+    public struct Settings
+    {
+        public float CutoffHz;
+        public float Mix;
+        public bool VelocityAffectsMix;
+        public Func<float, float>? MixVelocityCurve;
+    }
+
+    public static HighPassFilterEffect Create(in Settings settings)
     {
         var ret = _pool.Value.Rent();
-        ret.Construct(cutoffHz);
-        ret.mix = mix;
-        ret.velocityAffectsMix = velocityAffectsMix;
-        ret.mixVelocityCurve = mixVelocityCurve ?? EffectContext.EaseLinear;
+        ret.Construct(settings.CutoffHz);
+        ret.mix = settings.Mix;
+        ret.velocityAffectsMix = settings.VelocityAffectsMix;
+        ret.mixVelocityCurve = settings.MixVelocityCurve ?? EffectContext.EaseLinear;
         return ret;
     }
 
@@ -37,7 +42,17 @@ public class HighPassFilterEffect : Recyclable, IEffect
         this.cutoffHz = cutoffHz;
     }
 
-    public IEffect Clone() => HighPassFilterEffect.Create(cutoffHz, mix, velocityAffectsMix, mixVelocityCurve);
+    public IEffect Clone()
+    {
+        var settings = new Settings
+        {
+            CutoffHz = cutoffHz,
+            Mix = mix,
+            VelocityAffectsMix = velocityAffectsMix,
+            MixVelocityCurve = mixVelocityCurve
+        };
+        return Create(in settings);
+    }
 
     public float Process(in EffectContext ctx)
     {

--- a/src/klooie/Audio/SignalProcessing/Effects/LowPassFilterEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/LowPassFilterEffect.cs
@@ -18,16 +18,21 @@ class LowPassFilterEffect : Recyclable, IEffect
 
     private LowPassFilterEffect() { }
 
-    public static LowPassFilterEffect Create(float cutoffHz = 200f,
-        float mix = 1f,
-        bool velocityAffectsMix = true,
-        Func<float, float>? mixVelocityCurve = null)
+    public struct Settings
+    {
+        public float CutoffHz;
+        public float Mix;
+        public bool VelocityAffectsMix;
+        public Func<float, float>? MixVelocityCurve;
+    }
+
+    public static LowPassFilterEffect Create(in Settings settings)
     {
         var fx = _pool.Value.Rent();
-        fx.Construct(cutoffHz);
-        fx.mix = mix;
-        fx.velocityAffectsMix = velocityAffectsMix;
-        fx.mixVelocityCurve = mixVelocityCurve ?? EffectContext.EaseLinear;
+        fx.Construct(settings.CutoffHz);
+        fx.mix = settings.Mix;
+        fx.velocityAffectsMix = settings.VelocityAffectsMix;
+        fx.mixVelocityCurve = settings.MixVelocityCurve ?? EffectContext.EaseLinear;
         return fx;
     }
 
@@ -40,7 +45,17 @@ class LowPassFilterEffect : Recyclable, IEffect
         state = 0f;
     }
 
-    public IEffect Clone() => LowPassFilterEffect.Create(cutoffHz, mix, velocityAffectsMix, mixVelocityCurve);
+    public IEffect Clone()
+    {
+        var settings = new Settings
+        {
+            CutoffHz = cutoffHz,
+            Mix = mix,
+            VelocityAffectsMix = velocityAffectsMix,
+            MixVelocityCurve = mixVelocityCurve
+        };
+        return Create(in settings);
+    }
 
     public float Process(in EffectContext ctx)
     {

--- a/src/klooie/Audio/SignalProcessing/Effects/PickTransientEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/PickTransientEffect.cs
@@ -19,17 +19,31 @@ public sealed class PickTransientEffect : Recyclable, IEffect
         new(() => new PickTransientEffect());
     private PickTransientEffect() { rng = new Random(); }
 
-    public static PickTransientEffect Create(float duration = .005f, float gain = .6f)
+    public struct Settings
+    {
+        public float Duration;
+        public float Gain;
+    }
+
+    public static PickTransientEffect Create(in Settings settings)
     {
         var fx = _pool.Value.Rent();
-        fx.duration = duration;
-        fx.gain = gain;
+        fx.duration = settings.Duration;
+        fx.gain = settings.Gain;
         fx.timeSinceOn = 0f;
         fx.active = true;
         return fx;
     }
 
-    public IEffect Clone() => Create(duration, gain);
+    public IEffect Clone()
+    {
+        var settings = new Settings
+        {
+            Duration = duration,
+            Gain = gain
+        };
+        return Create(in settings);
+    }
 
     public float Process(in EffectContext ctx)
     {

--- a/src/klooie/Audio/SignalProcessing/Effects/PitchBendEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/PitchBendEffect.cs
@@ -18,13 +18,21 @@ public class PitchBendEffect : Recyclable, IPitchModEffect
 
     private PitchBendEffect() { }
 
-    public static PitchBendEffect Create(Func<float, float> attackBend, float attackDur, Func<float, float> releaseBend, float releaseDur)
+    public struct Settings
+    {
+        public Func<float, float> AttackBend;
+        public float AttackDuration;
+        public Func<float, float> ReleaseBend;
+        public float ReleaseDuration;
+    }
+
+    public static PitchBendEffect Create(in Settings settings)
     {
         var fx = _pool.Value.Rent();
-        fx.attackBendFunc = attackBend;
-        fx.attackDuration = attackDur;
-        fx.releaseBendFunc = releaseBend;
-        fx.releaseDuration = releaseDur;
+        fx.attackBendFunc = settings.AttackBend;
+        fx.attackDuration = settings.AttackDuration;
+        fx.releaseBendFunc = settings.ReleaseBend;
+        fx.releaseDuration = settings.ReleaseDuration;
         return fx;
     }
 
@@ -48,7 +56,17 @@ public class PitchBendEffect : Recyclable, IPitchModEffect
 
     public float Process(in EffectContext ctx) => ctx.Input;
 
-    public IEffect Clone() => Create(attackBendFunc, attackDuration, releaseBendFunc, releaseDuration);
+    public IEffect Clone()
+    {
+        var settings = new Settings
+        {
+            AttackBend = attackBendFunc,
+            AttackDuration = attackDuration,
+            ReleaseBend = releaseBendFunc,
+            ReleaseDuration = releaseDuration
+        };
+        return Create(in settings);
+    }
 
     protected override void OnReturn()
     {

--- a/src/klooie/Audio/SignalProcessing/Effects/PresenceShelfEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/PresenceShelfEffect.cs
@@ -30,20 +30,34 @@ public sealed class PresenceShelfEffect : Recyclable, IEffect
 
     private PresenceShelfEffect() { }
 
-    public static PresenceShelfEffect Create(float presenceDb = +3f,
-        Func<float, float>? velocityCurve = null,
-        float velocityScale = 1f)
+    public struct Settings
+    {
+        public float PresenceDb;
+        public Func<float, float>? VelocityCurve;
+        public float VelocityScale;
+    }
+
+    public static PresenceShelfEffect Create(in Settings settings)
     {
         var fx = _pool.Value.Rent();
-        fx.shelfGain = MathF.Pow(10f, presenceDb / 20f);
+        fx.shelfGain = MathF.Pow(10f, settings.PresenceDb / 20f);
         fx.Configure();
         fx.resY1 = fx.resY2 = fx.lp = 0f;
-        fx.velocityCurve = velocityCurve ?? EffectContext.EaseLinear;
-        fx.velocityScale = velocityScale;
+        fx.velocityCurve = settings.VelocityCurve ?? EffectContext.EaseLinear;
+        fx.velocityScale = settings.VelocityScale;
         return fx;
     }
 
-    public IEffect Clone() => Create(20f * MathF.Log10(shelfGain), velocityCurve, velocityScale);
+    public IEffect Clone()
+    {
+        var settings = new Settings
+        {
+            PresenceDb = 20f * MathF.Log10(shelfGain),
+            VelocityCurve = velocityCurve,
+            VelocityScale = velocityScale
+        };
+        return Create(in settings);
+    }
 
     /* ----- core ---------------------------------------------------------- */
     public float Process(in EffectContext ctx)

--- a/src/klooie/Audio/SignalProcessing/Effects/ReverbEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/ReverbEffect.cs
@@ -101,14 +101,22 @@ public class ReverbEffect : Recyclable, IEffect
 
     private static LazyPool<ReverbEffect> _pool = new(() => new ReverbEffect());
     protected ReverbEffect() { }
-    public static ReverbEffect Create(float feedback = 0.78f, float diffusion = 0.5f, float wet = 0.3f, float dry = 0.7f,
-        bool velocityAffectsMix = true,
-        Func<float, float>? mixVelocityCurve = null)
+    public struct Settings
+    {
+        public float Feedback;
+        public float Diffusion;
+        public float Wet;
+        public float Dry;
+        public bool VelocityAffectsMix;
+        public Func<float, float>? MixVelocityCurve;
+    }
+
+    public static ReverbEffect Create(in Settings settings)
     {
         var ret = _pool.Value.Rent();
-        ret.Construct(feedback, diffusion, wet, dry);
-        ret.velocityAffectsMix = velocityAffectsMix;
-        ret.mixVelocityCurve = mixVelocityCurve ?? EffectContext.EaseLinear;
+        ret.Construct(settings.Feedback, settings.Diffusion, settings.Wet, settings.Dry);
+        ret.velocityAffectsMix = settings.VelocityAffectsMix;
+        ret.mixVelocityCurve = settings.MixVelocityCurve ?? EffectContext.EaseLinear;
         return ret;
     }
 
@@ -130,7 +138,19 @@ public class ReverbEffect : Recyclable, IEffect
         this.dry = dry;
     }
 
-    public IEffect Clone() => Create(feedback, diffusion, wet, dry, velocityAffectsMix, mixVelocityCurve);
+    public IEffect Clone()
+    {
+        var settings = new Settings
+        {
+            Feedback = feedback,
+            Diffusion = diffusion,
+            Wet = wet,
+            Dry = dry,
+            VelocityAffectsMix = velocityAffectsMix,
+            MixVelocityCurve = mixVelocityCurve
+        };
+        return Create(in settings);
+    }
 
     public float Process(in EffectContext ctx)
     {

--- a/src/klooie/Audio/SignalProcessing/Effects/StereoChorusEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/StereoChorusEffect.cs
@@ -18,18 +18,38 @@ public class StereoChorusEffect : Recyclable, IEffect
 
     private static LazyPool<StereoChorusEffect> _pool = new(() => new StereoChorusEffect());
     protected StereoChorusEffect() { }
-    public static StereoChorusEffect Create(int delayMs = 20, int depthMs = 6, float rateHz = 0.4f, float mix = 0.3f,
-        bool velocityAffectsMix = true,
-        Func<float, float>? mixVelocityCurve = null)
+    public struct Settings
+    {
+        public int DelayMs;
+        public int DepthMs;
+        public float RateHz;
+        public float Mix;
+        public bool VelocityAffectsMix;
+        public Func<float, float>? MixVelocityCurve;
+    }
+
+    public static StereoChorusEffect Create(in Settings settings)
     {
         var ret = _pool.Value.Rent();
-        ret.Construct(delayMs, depthMs, rateHz, mix);
-        ret.velocityAffectsMix = velocityAffectsMix;
-        ret.mixVelocityCurve = mixVelocityCurve ?? EffectContext.EaseLinear;
+        ret.Construct(settings.DelayMs, settings.DepthMs, settings.RateHz, settings.Mix);
+        ret.velocityAffectsMix = settings.VelocityAffectsMix;
+        ret.mixVelocityCurve = settings.MixVelocityCurve ?? EffectContext.EaseLinear;
         return ret;
     }
 
-    public IEffect Clone() => Create(delayMs, depthMs, rateHz, mix, velocityAffectsMix, mixVelocityCurve);
+    public IEffect Clone()
+    {
+        var settings = new Settings
+        {
+            DelayMs = delayMs,
+            DepthMs = depthMs,
+            RateHz = rateHz,
+            Mix = mix,
+            VelocityAffectsMix = velocityAffectsMix,
+            MixVelocityCurve = mixVelocityCurve
+        };
+        return Create(in settings);
+    }
 
     protected void Construct(int delayMs = 20, int depthMs = 6, float rateHz = 0.4f, float mix = 0.3f)
     {

--- a/src/klooie/Audio/SignalProcessing/Effects/TiltEQEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/TiltEQEffect.cs
@@ -16,10 +16,16 @@ public sealed class TiltEQEffect : Recyclable, IEffect
     private static readonly LazyPool<TiltEQEffect> _pool = new(() => new TiltEQEffect());
     private TiltEQEffect() { }
 
-    public static TiltEQEffect Create(float tilt = 0.0f, float cutoffHz = 200f)
+    public struct Settings
+    {
+        public float Tilt;
+        public float CutoffHz;
+    }
+
+    public static TiltEQEffect Create(in Settings settings)
     {
         var fx = _pool.Value.Rent();
-        fx.Construct(tilt, cutoffHz);
+        fx.Construct(settings.Tilt, settings.CutoffHz);
         return fx;
     }
 
@@ -33,7 +39,15 @@ public sealed class TiltEQEffect : Recyclable, IEffect
         low = 0f;
     }
 
-    public IEffect Clone() => Create(tilt, cutoffHz);
+    public IEffect Clone()
+    {
+        var settings = new Settings
+        {
+            Tilt = tilt,
+            CutoffHz = cutoffHz
+        };
+        return Create(in settings);
+    }
 
     public float Process(in EffectContext ctx)
     {

--- a/src/klooie/Audio/SignalProcessing/Effects/ToneStackEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/ToneStackEffect.cs
@@ -28,22 +28,40 @@ public sealed class ToneStackEffect : Recyclable, IEffect
         new(() => new ToneStackEffect());
     private ToneStackEffect() { }
 
-    public static ToneStackEffect Create(float bass = 1f, float mid = 1f, float treble = 1f,
-        bool velocityAffectsGain = true,
-        Func<float, float>? gainVelocityCurve = null)
+    public struct Settings
+    {
+        public float Bass;
+        public float Mid;
+        public float Treble;
+        public bool VelocityAffectsGain;
+        public Func<float, float>? GainVelocityCurve;
+    }
+
+    public static ToneStackEffect Create(in Settings settings)
     {
         var fx = _pool.Value.Rent();
-        fx.bassG = bass;
-        fx.midG = mid;
-        fx.trebG = treble;
+        fx.bassG = settings.Bass;
+        fx.midG = settings.Mid;
+        fx.trebG = settings.Treble;
         fx.lowLpf = 0f;
         fx.highLpf = 0f;
-        fx.velocityAffectsGain = velocityAffectsGain;
-        fx.gainVelocityCurve = gainVelocityCurve ?? EffectContext.EaseLinear;
+        fx.velocityAffectsGain = settings.VelocityAffectsGain;
+        fx.gainVelocityCurve = settings.GainVelocityCurve ?? EffectContext.EaseLinear;
         return fx;
     }
 
-    public IEffect Clone() => Create(bassG, midG, trebG, velocityAffectsGain, gainVelocityCurve);
+    public IEffect Clone()
+    {
+        var settings = new Settings
+        {
+            Bass = bassG,
+            Mid = midG,
+            Treble = trebG,
+            VelocityAffectsGain = velocityAffectsGain,
+            GainVelocityCurve = gainVelocityCurve
+        };
+        return Create(in settings);
+    }
 
     public float Process(in EffectContext ctx)
     {

--- a/src/klooie/Audio/SignalProcessing/Effects/TremoloEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/TremoloEffect.cs
@@ -12,18 +12,34 @@ public class TremoloEffect : Recyclable, IEffect
     private static readonly LazyPool<TremoloEffect> _pool = new(() => new TremoloEffect());
     protected TremoloEffect() { }
 
-    public static TremoloEffect Create(float depth = 0.5f, float rateHz = 5f,
-        bool velocityAffectsDepth = true,
-        Func<float, float>? depthVelocityCurve = null)
+    public struct Settings
+    {
+        public float Depth;
+        public float RateHz;
+        public bool VelocityAffectsDepth;
+        public Func<float, float>? DepthVelocityCurve;
+    }
+
+    public static TremoloEffect Create(in Settings settings)
     {
         var ret = _pool.Value.Rent();
-        ret.Construct(depth, rateHz);
-        ret.velocityAffectsDepth = velocityAffectsDepth;
-        ret.depthVelocityCurve = depthVelocityCurve ?? EffectContext.EaseLinear;
+        ret.Construct(settings.Depth, settings.RateHz);
+        ret.velocityAffectsDepth = settings.VelocityAffectsDepth;
+        ret.depthVelocityCurve = settings.DepthVelocityCurve ?? EffectContext.EaseLinear;
         return ret;
     }
 
-    public IEffect Clone() => Create(depth, rateHz, velocityAffectsDepth, depthVelocityCurve);
+    public IEffect Clone()
+    {
+        var settings = new Settings
+        {
+            Depth = depth,
+            RateHz = rateHz,
+            VelocityAffectsDepth = velocityAffectsDepth,
+            DepthVelocityCurve = depthVelocityCurve
+        };
+        return Create(in settings);
+    }
 
     protected void Construct(float depth, float rateHz)
     {

--- a/src/klooie/Audio/SignalProcessing/Effects/VolumeEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/VolumeEffect.cs
@@ -18,21 +18,31 @@ public class VolumeEffect : Recyclable, IEffect
     private VolumeEffect() { }
     static readonly LazyPool<VolumeEffect> _pool = new(() => new VolumeEffect());
 
-    public static VolumeEffect Create(
-        float gain = 1.0f,
-        Func<float, float>? velocityCurve = null,
-        float velocityScale = 1f)
-    {
-        var fx = _pool.Value.Rent();
-        fx.gain = gain;
-        fx.velocityCurve = velocityCurve ?? EffectContext.EaseLinear;
-        fx.velocityScale = velocityScale;
-        return fx;
-    }
+public struct Settings
+{
+    public float Gain;
+    public Func<float, float>? VelocityCurve;
+    public float VelocityScale;
+}
+
+public static VolumeEffect Create(in Settings settings)
+{
+    var fx = _pool.Value.Rent();
+    fx.gain = settings.Gain;
+    fx.velocityCurve = settings.VelocityCurve ?? EffectContext.EaseLinear;
+    fx.velocityScale = settings.VelocityScale;
+    return fx;
+}
 
     public IEffect Clone()
     {
-        return Create(gain, velocityCurve, velocityScale);
+        var settings = new Settings
+        {
+            Gain = gain,
+            VelocityCurve = velocityCurve,
+            VelocityScale = velocityScale
+        };
+        return Create(in settings);
     }
 
     public float Process(in EffectContext ctx)

--- a/src/klooie/Audio/SignalProcessing/Patches/SynthPatch.cs
+++ b/src/klooie/Audio/SignalProcessing/Patches/SynthPatch.cs
@@ -117,85 +117,274 @@ public static class SynthPatchExtensions
 
 
     public static ISynthPatch WithCabinet(this ISynthPatch patch)
-        => patch.WithEffect(CabinetEffect.Create());
+    {
+        var settings = new CabinetEffect.Settings { VelocityScale = 1f };
+        return patch.WithEffect(CabinetEffect.Create(in settings));
+    }
 
     public static ISynthPatch WithReverb(this ISynthPatch patch, float feedback = 0.78f, float diffusion = 0.5f, float wet = 0.3f, float dry = 0.7f)
-        => patch.WithEffect(ReverbEffect.Create(feedback, diffusion, wet, dry));
+    {
+        var settings = new ReverbEffect.Settings
+        {
+            Feedback = feedback,
+            Diffusion = diffusion,
+            Wet = wet,
+            Dry = dry,
+            VelocityAffectsMix = true
+        };
+        return patch.WithEffect(ReverbEffect.Create(in settings));
+    }
 
     public static ISynthPatch WithDelay(this ISynthPatch patch, int delaySamples, float feedback = .3f, float mix = .4f)
-        => patch.WithEffect(DelayEffect.Create(delaySamples, feedback, mix));
+    {
+        var settings = new DelayEffect.Settings
+        {
+            DelaySamples = delaySamples,
+            Feedback = feedback,
+            Mix = mix,
+            VelocityAffectsMix = true
+        };
+        return patch.WithEffect(DelayEffect.Create(in settings));
+    }
 
     public static ISynthPatch WithChorus(this ISynthPatch patch, int delayMs = 22, int depthMs = 7, float rateHz = 0.22f, float mix = 0.19f)
-        => patch.WithEffect(StereoChorusEffect.Create(delayMs, depthMs, rateHz, mix));
+    {
+        var settings = new StereoChorusEffect.Settings
+        {
+            DelayMs = delayMs,
+            DepthMs = depthMs,
+            RateHz = rateHz,
+            Mix = mix,
+            VelocityAffectsMix = true
+        };
+        return patch.WithEffect(StereoChorusEffect.Create(in settings));
+    }
 
     public static ISynthPatch WithTremolo(this ISynthPatch patch, float depth = 0.5f, float rateHz = 5f)
-        => patch.WithEffect(TremoloEffect.Create(depth, rateHz));
+    {
+        var settings = new TremoloEffect.Settings
+        {
+            Depth = depth,
+            RateHz = rateHz,
+            VelocityAffectsDepth = true
+        };
+        return patch.WithEffect(TremoloEffect.Create(in settings));
+    }
 
     public static ISynthPatch WithHighPass(this ISynthPatch patch, float cutoffHz = 200f)
-        => patch.WithEffect(HighPassFilterEffect.Create(cutoffHz));
+    {
+        var settings = new HighPassFilterEffect.Settings
+        {
+            CutoffHz = cutoffHz,
+            Mix = 1f,
+            VelocityAffectsMix = true
+        };
+        return patch.WithEffect(HighPassFilterEffect.Create(in settings));
+    }
 
     public static ISynthPatch WithLowPass(this ISynthPatch patch, float cutoffHz = 200f)
-        => patch.WithEffect(LowPassFilterEffect.Create(cutoffHz));
+    {
+        var settings = new LowPassFilterEffect.Settings
+        {
+            CutoffHz = cutoffHz,
+            Mix = 1f,
+            VelocityAffectsMix = true
+        };
+        return patch.WithEffect(LowPassFilterEffect.Create(in settings));
+    }
 
     public static ISynthPatch WithDistortion(this ISynthPatch patch, float drive = 6f, float stageRatio = 0.6f, float bias = 0.15f)
-        => patch.WithEffect(DistortionEffect.Create(drive, stageRatio, bias));
+    {
+        var settings = new DistortionEffect.Settings
+        {
+            Drive = drive,
+            StageRatio = stageRatio,
+            Bias = bias,
+            VelocityScale = 1f
+        };
+        return patch.WithEffect(DistortionEffect.Create(in settings));
+    }
 
     public static ISynthPatch WithAggroDistortion(this ISynthPatch patch, float drive = 12f, float stageRatio = 0.8f, float bias = 0.12f)
-        => patch.WithEffect(AggroDistortionEffect.Create(drive, stageRatio, bias));
+    {
+        var settings = new AggroDistortionEffect.Settings
+        {
+            Drive = drive,
+            StageRatio = stageRatio,
+            Bias = bias,
+            VelocityScale = 1f
+        };
+        return patch.WithEffect(AggroDistortionEffect.Create(in settings));
+    }
 
     public static ISynthPatch WithVolume(this ISynthPatch patch, float volume = 1.0f)
-        => patch.WithEffect(VolumeEffect.Create(volume));
+    {
+        var settings = new VolumeEffect.Settings { Gain = volume, VelocityScale = 1f };
+        return patch.WithEffect(VolumeEffect.Create(in settings));
+    }
 
     public static ISynthPatch WithPitchBend(
         this ISynthPatch patch,
         Func<float, float> attackBendFunc, float attackDuration,
         Func<float, float> releaseBendFunc, float releaseDuration)
-        => patch.WithEffect(PitchBendEffect.Create(attackBendFunc, attackDuration, releaseBendFunc, releaseDuration));
+    {
+        var settings = new PitchBendEffect.Settings
+        {
+            AttackBend = attackBendFunc,
+            AttackDuration = attackDuration,
+            ReleaseBend = releaseBendFunc,
+            ReleaseDuration = releaseDuration
+        };
+        return patch.WithEffect(PitchBendEffect.Create(in settings));
+    }
 
     public static ISynthPatch WithPitchBend(
     this ISynthPatch patch,
     Func<float, float> bendFunc, float duration)
-    => patch.WithEffect(PitchBendEffect.Create(
-        attackBend: bendFunc, attackDur: duration,
-        releaseBend: t => 0f, releaseDur: 0.001f)); // Release bend = no bend
+    {
+        var settings = new PitchBendEffect.Settings
+        {
+            AttackBend = bendFunc,
+            AttackDuration = duration,
+            ReleaseBend = t => 0f,
+            ReleaseDuration = 0.001f
+        };
+        return patch.WithEffect(PitchBendEffect.Create(in settings));
+    }
 
     public static ISynthPatch WithNoiseGate(this ISynthPatch patch, float openThresh = 0.05f, float closeThresh = 0.04f, float attackMs = 2f, float releaseMs = 60f)
-        => patch.WithEffect(NoiseGateEffect.Create(openThresh, closeThresh, attackMs, releaseMs));
+    {
+        var settings = new NoiseGateEffect.Settings
+        {
+            OpenThresh = openThresh,
+            CloseThresh = closeThresh,
+            AttackMs = attackMs,
+            ReleaseMs = releaseMs,
+            VelocityAffectsThreshold = true
+        };
+        return patch.WithEffect(NoiseGateEffect.Create(in settings));
+    }
 
     public static ISynthPatch WithFadeIn(this ISynthPatch patch, float durationSeconds = 1.5f)
-        => patch.WithEffect(FadeInEffect.Create(durationSeconds));
+    {
+        var settings = new FadeInEffect.Settings
+        {
+            DurationSeconds = durationSeconds,
+            VelocityScale = 1f
+        };
+        return patch.WithEffect(FadeInEffect.Create(in settings));
+    }
 
     public static ISynthPatch WithFadeOut(this ISynthPatch patch, float durationSeconds = 1.5f)
-        => patch.WithEffect(FadeOutEffect.Create(durationSeconds));
+    {
+        var settings = new FadeOutEffect.Settings
+        {
+            DurationSeconds = durationSeconds,
+            FadeStartTime = 0f,
+            VelocityScale = 1f
+        };
+        return patch.WithEffect(FadeOutEffect.Create(in settings));
+    }
 
     public static ISynthPatch WithEnvelope(this ISynthPatch patch, double attackMs, double decayMs, double sustainLevel, double releaseMs)
-        => patch.WithEffect(EnvelopeEffect.Create(attackMs, decayMs, sustainLevel, releaseMs));
+    {
+        var settings = new EnvelopeEffect.Settings
+        {
+            Attack = attackMs,
+            Decay = decayMs,
+            Sustain = sustainLevel,
+            Release = releaseMs
+        };
+        return patch.WithEffect(EnvelopeEffect.Create(in settings));
+    }
 
     public static ISynthPatch WithToneStack(this ISynthPatch patch, float bass = 1f, float mid = 1f, float treble = 1f)
-        => patch.WithEffect(ToneStackEffect.Create(bass, mid, treble));
+    {
+        var settings = new ToneStackEffect.Settings
+        {
+            Bass = bass,
+            Mid = mid,
+            Treble = treble,
+            VelocityAffectsGain = true
+        };
+        return patch.WithEffect(ToneStackEffect.Create(in settings));
+    }
 
     public static ISynthPatch WithPresenceShelf(this ISynthPatch patch, float presenceDb = +3f)
-        => patch.WithEffect(PresenceShelfEffect.Create(presenceDb));
+    {
+        var settings = new PresenceShelfEffect.Settings
+        {
+            PresenceDb = presenceDb,
+            VelocityScale = 1f
+        };
+        return patch.WithEffect(PresenceShelfEffect.Create(in settings));
+    }
 
     public static ISynthPatch WithPickTransient(this ISynthPatch patch, float dur = .005f, float gain = .6f)
-        => patch.WithEffect(PickTransientEffect.Create(dur, gain));
+    {
+        var settings = new PickTransientEffect.Settings { Duration = dur, Gain = gain };
+        return patch.WithEffect(PickTransientEffect.Create(in settings));
+    }
 
     public static ISynthPatch WithDCBlocker(this ISynthPatch patch)
-        => patch.WithEffect(DCBlockerEffect.Create());
+    {
+        var settings = new DCBlockerEffect.Settings();
+        return patch.WithEffect(DCBlockerEffect.Create(in settings));
+    }
 
     public static ISynthPatch WithPeakEQ(this ISynthPatch patch, float freq, float gainDb, float q = 1.0f)
-        => patch.WithEffect(ParametricEQEffect.Create(BiquadType.Peak, freq, gainDb, q));
+    {
+        var settings = new ParametricEQEffect.Settings
+        {
+            Type = BiquadType.Peak,
+            Freq = freq,
+            GainDb = gainDb,
+            Q = q,
+            VelocityAffectsGain = true,
+            GainVelocityScale = 1f
+        };
+        return patch.WithEffect(ParametricEQEffect.Create(in settings));
+    }
 
     public static ISynthPatch WithLowShelf(this ISynthPatch patch, float freq, float gainDb)
-        => patch.WithEffect(ParametricEQEffect.Create(BiquadType.LowShelf, freq, gainDb));
+    {
+        var settings = new ParametricEQEffect.Settings
+        {
+            Type = BiquadType.LowShelf,
+            Freq = freq,
+            GainDb = gainDb,
+            Q = 1f,
+            VelocityAffectsGain = true,
+            GainVelocityScale = 1f
+        };
+        return patch.WithEffect(ParametricEQEffect.Create(in settings));
+    }
 
     public static ISynthPatch WithHighShelf(this ISynthPatch patch, float freq, float gainDb)
-        => patch.WithEffect(ParametricEQEffect.Create(BiquadType.HighShelf, freq, gainDb));
+    {
+        var settings = new ParametricEQEffect.Settings
+        {
+            Type = BiquadType.HighShelf,
+            Freq = freq,
+            GainDb = gainDb,
+            Q = 1f,
+            VelocityAffectsGain = true,
+            GainVelocityScale = 1f
+        };
+        return patch.WithEffect(ParametricEQEffect.Create(in settings));
+    }
 
     public static ISynthPatch WithPingPongDelay(this ISynthPatch patch, float delayMs = 330f, float feedback = 0.45f, float mix = 0.36f)
     {
         int delaySamples = (int)(delayMs * SoundProvider.SampleRate / 1000.0);
-        return patch.WithEffect(PingPongDelayEffect.Create(delaySamples, feedback, mix));
+        var settings = new PingPongDelayEffect.Settings
+        {
+            DelaySamples = delaySamples,
+            Feedback = feedback,
+            Mix = mix,
+            VelocityAffectsMix = true
+        };
+        return patch.WithEffect(PingPongDelayEffect.Create(in settings));
     }
 
     // ----- Property: applies to all leaves -----


### PR DESCRIPTION
## Summary
- move every IEffect class to take a struct-based Settings argument
- adjust SynthPatch helpers to build these Settings and keep a clean call site

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a5db36f988325846b15576ffccf3e