### PR TITLE
Add doc attributes to all effects

### DIFF
--- a/src/klooie/Audio/SignalProcessing/Effects/AggroDistortionEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/AggroDistortionEffect.cs
@@ -2,6 +2,10 @@
 
 namespace klooie;
 
+[SynthDescription("""
+Aggressive multi-stage distortion with oversampling for heavy tones.
+""")]
+[SynthCategory("Distortion")]
 public sealed class AggroDistortionEffect : Recyclable, IEffect
 {
     /* -------- parameters (public API) ------------------------------------ */
@@ -23,12 +27,24 @@ public sealed class AggroDistortionEffect : Recyclable, IEffect
 
     private AggroDistortionEffect() { }
 
+    [SynthDescription("""
+    Parameters for AggroDistortionEffect.
+    """)]
     public struct Settings
     {
+        [SynthDescription("""Input drive level.""")]
         public float Drive;
+
+        [SynthDescription("""Gain ratio between each distortion stage.""")]
         public float StageRatio;
+
+        [SynthDescription("""Bias for asymmetric clipping.""")]
         public float Bias;
+
+        [SynthDescription("""Optional velocity-to-gain curve.""")]
         public Func<float, float>? VelocityCurve;
+
+        [SynthDescription("""Scale factor applied to the velocity curve.""")]
         public float VelocityScale;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/CabinetEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/CabinetEffect.cs
@@ -5,6 +5,10 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace klooie;
+[SynthDescription("""
+Cabinet simulator using shelf filters and a mid scoop to mimic guitar cabinets.
+""")]
+[SynthCategory("Filter")]
 class CabinetEffect : Recyclable, IEffect
 {
     // shelves + mid scoop
@@ -18,9 +22,15 @@ class CabinetEffect : Recyclable, IEffect
     static readonly LazyPool<CabinetEffect> _pool =
         new(() => new CabinetEffect());
 
+    [SynthDescription("""
+    Parameters for CabinetEffect.
+    """)]
     public struct Settings
     {
+        [SynthDescription("""Curve scaling output based on note velocity.""")]
         public Func<float, float>? VelocityCurve;
+
+        [SynthDescription("""Multiplier applied to the velocity curve.""")]
         public float VelocityScale;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/CompressorEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/CompressorEffect.cs
@@ -6,6 +6,10 @@ namespace klooie;
 /// Simple peak/RMS hybrid compressor – great for taming post-amp transients
 /// without crushing pick attack.
 /// </summary>
+[SynthDescription("""
+Peak/RMS hybrid compressor for controlling dynamic range.
+""")]
+[SynthCategory("Dynamics")]
 public sealed class CompressorEffect : Recyclable, IEffect
 {
     /* --- tunables ------------------------------------------------------- */
@@ -24,13 +28,27 @@ public sealed class CompressorEffect : Recyclable, IEffect
     private static readonly LazyPool<CompressorEffect> _pool = new(() => new CompressorEffect());
     private CompressorEffect() { }
 
+    [SynthDescription("""
+    Parameters for CompressorEffect.
+    """)]
     public struct Settings
     {
+        [SynthDescription("""Threshold level before compression occurs.""")]
         public float Threshold;
+
+        [SynthDescription("""Compression ratio.""")]
         public float Ratio;
+
+        [SynthDescription("""Attack time coefficient.""")]
         public float Attack;
+
+        [SynthDescription("""Release time coefficient.""")]
         public float Release;
+
+        [SynthDescription("""Velocity-to-gain curve.""")]
         public Func<float, float>? VelocityCurve;
+
+        [SynthDescription("""Scale factor for velocity curve.""")]
         public float VelocityScale;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/DCBlockerEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/DCBlockerEffect.cs
@@ -6,6 +6,10 @@ namespace klooie;
 /// First-order DC-block / 15 Hz high-pass.
 /// Removes sub-audible offsets that become “pops” after heavy drive.
 /// </summary>
+[SynthDescription("""
+High-pass filter at 15 Hz to remove DC offsets.
+""")]
+[SynthCategory("Filter")]
 public sealed class DCBlockerEffect : Recyclable, IEffect
 {
     private const float fCut = 15f;          // cutoff Hz
@@ -19,9 +23,15 @@ public sealed class DCBlockerEffect : Recyclable, IEffect
         new(() => new DCBlockerEffect());
     private DCBlockerEffect() { }
 
+    [SynthDescription("""
+    Parameters for DCBlockerEffect.
+    """)]
     public struct Settings
     {
+        [SynthDescription("""When true, velocity scales the output level.""")]
         public bool VelocityAffectsOutput;
+
+        [SynthDescription("""Curve used when velocity affects output.""")]
         public Func<float, float>? VelocityCurve;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/DelayEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/DelayEffect.cs
@@ -5,6 +5,12 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace klooie;
+[SynthDescription("""
+Creates a basic delay line that echoes the input after a
+specified number of samples. Feedback controls how much of
+the delayed signal is fed back for repeating echoes.
+""")]
+[SynthCategory("Delay")]
 public class DelayEffect : Recyclable, IEffect
 {
     private float[] buffer;
@@ -15,12 +21,26 @@ public class DelayEffect : Recyclable, IEffect
 
     private static LazyPool<DelayEffect> _pool = new(() => new DelayEffect()); // Default 1 second delay at 44100Hz
     protected DelayEffect() { }
+
+    [SynthDescription("""
+    Parameters used when creating a DelayEffect instance.
+    All values are in sample or normalized units.
+    """)]
     public struct Settings
     {
+        [SynthDescription("""Number of samples to delay the signal.""")]
         public int DelaySamples;
+
+        [SynthDescription("""Amount of feedback returned to the delay line (0-1).""")]
         public float Feedback;
+
+        [SynthDescription("""Blend between dry and delayed signal (0-1).""")]
         public float Mix;
+
+        [SynthDescription("""When true, note velocity scales the mix amount.""")]
         public bool VelocityAffectsMix;
+
+        [SynthDescription("""Curve that maps normalized velocity to a mix multiplier.""")]
         public Func<float, float>? MixVelocityCurve;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/DistortionEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/DistortionEffect.cs
@@ -5,6 +5,10 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace klooie;
+[SynthDescription("""
+Multi-stage soft-clipping distortion effect with simple oversampling to reduce aliasing.
+""")]
+[SynthCategory("Distortion")]
 class DistortionEffect : Recyclable, IEffect
 {
     // 2× oversample using linear interp, 3 gain stages, tanh softclip
@@ -19,12 +23,24 @@ class DistortionEffect : Recyclable, IEffect
     private DistortionEffect() { }
     static readonly LazyPool<DistortionEffect> _pool = new(() => new DistortionEffect());
 
+    [SynthDescription("""
+    Parameters for DistortionEffect.
+    """)]
     public struct Settings
     {
+        [SynthDescription("""Input gain before distortion stages.""")]
         public float Drive;
+
+        [SynthDescription("""Relative gain drop for each successive stage.""")]
         public float StageRatio;
+
+        [SynthDescription("""Asymmetry bias added to the clipper.""")]
         public float Bias;
+
+        [SynthDescription("""Optional curve mapping velocity to gain scale.""")]
         public Func<float, float>? VelocityCurve;
+
+        [SynthDescription("""Multiplier applied to the velocity curve.""")]
         public float VelocityScale;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/EnvelopeEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/EnvelopeEffect.cs
@@ -5,6 +5,10 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace klooie;
+[SynthDescription("""
+ADSR envelope generator that modulates the input signal level.
+""")]
+[SynthCategory("Dynamics")]
 public class EnvelopeEffect : Recyclable, IEffect
 {
     public ADSREnvelope Envelope { get; private set; }
@@ -13,11 +17,21 @@ public class EnvelopeEffect : Recyclable, IEffect
 
     private EnvelopeEffect() { }
 
+    [SynthDescription("""
+    Parameters for EnvelopeEffect.
+    """)]
     public struct Settings
     {
+        [SynthDescription("""Attack time in seconds.""")]
         public double Attack;
+
+        [SynthDescription("""Decay time in seconds.""")]
         public double Decay;
+
+        [SynthDescription("""Sustain level from 0-1.""")]
         public double Sustain;
+
+        [SynthDescription("""Release time in seconds.""")]
         public double Release;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/Fade.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/Fade.cs
@@ -7,6 +7,10 @@ using System.Threading.Tasks;
 namespace klooie;
 
 // FadeInEffect: Multiplies input by [0,1] fade-in envelope over the given duration
+[SynthDescription("""
+Applies a fade-in envelope to the signal over the specified duration.
+""")]
+[SynthCategory("Utility")]
 public class FadeInEffect : Recyclable, IEffect
 {
     private float fadeDuration;
@@ -18,10 +22,18 @@ public class FadeInEffect : Recyclable, IEffect
 
     private FadeInEffect() { }
 
+    [SynthDescription("""
+    Parameters for FadeInEffect.
+    """)]
     public struct Settings
     {
+        [SynthDescription("""Fade duration in seconds.""")]
         public float DurationSeconds;
+
+        [SynthDescription("""Optional velocity-to-gain curve.""")]
         public Func<float, float>? VelocityCurve;
+
+        [SynthDescription("""Scale factor applied to velocity curve.""")]
         public float VelocityScale;
     }
 
@@ -75,6 +87,10 @@ public class FadeInEffect : Recyclable, IEffect
         base.OnReturn();
     }
 }
+[SynthDescription("""
+Applies a fade-out envelope starting at the specified time.
+""")]
+[SynthCategory("Utility")]
 public class FadeOutEffect : Recyclable, IEffect
 {
     private float fadeDuration;
@@ -91,11 +107,21 @@ public class FadeOutEffect : Recyclable, IEffect
     /// durationSeconds: how long the fade should last
     /// fadeStartTime: time (in seconds) when fade should *start* (default = 0 to fade from the beginning)
     /// </summary>
+[SynthDescription("""
+Parameters for FadeOutEffect.
+""")]
 public struct Settings
 {
+    [SynthDescription("""Fade duration in seconds.""")]
     public float DurationSeconds;
+
+    [SynthDescription("""Time in seconds when fade should start.""")]
     public float FadeStartTime;
+
+    [SynthDescription("""Optional velocity-to-gain curve.""")]
     public Func<float, float>? VelocityCurve;
+
+    [SynthDescription("""Scale factor applied to velocity curve.""")]
     public float VelocityScale;
 }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/HighPassFilterEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/HighPassFilterEffect.cs
@@ -1,6 +1,10 @@
 using System;
 
 namespace klooie;
+[SynthDescription("""
+Simple one-pole high-pass filter.
+""")]
+[SynthCategory("Filter")]
 public class HighPassFilterEffect : Recyclable, IEffect
 {
     private float prevInput;
@@ -14,11 +18,21 @@ public class HighPassFilterEffect : Recyclable, IEffect
     private static readonly LazyPool<HighPassFilterEffect> _pool = new(() => new HighPassFilterEffect());
     protected HighPassFilterEffect() { }
 
+    [SynthDescription("""
+    Parameters for HighPassFilterEffect.
+    """)]
     public struct Settings
     {
+        [SynthDescription("""Cutoff frequency in Hz.""")]
         public float CutoffHz;
+
+        [SynthDescription("""Blend between dry and filtered signal.""")]
         public float Mix;
+
+        [SynthDescription("""When true, velocity scales the mix amount.""")]
         public bool VelocityAffectsMix;
+
+        [SynthDescription("""Curve for velocity-based mix scaling.""")]
         public Func<float, float>? MixVelocityCurve;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/LowPassFilterEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/LowPassFilterEffect.cs
@@ -5,6 +5,10 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace klooie;
+[SynthDescription("""
+First-order low-pass filter.
+""")]
+[SynthCategory("Filter")]
 class LowPassFilterEffect : Recyclable, IEffect
 {
     private float alpha;
@@ -18,11 +22,21 @@ class LowPassFilterEffect : Recyclable, IEffect
 
     private LowPassFilterEffect() { }
 
+    [SynthDescription("""
+    Parameters for LowPassFilterEffect.
+    """)]
     public struct Settings
     {
+        [SynthDescription("""Cutoff frequency in Hz.""")]
         public float CutoffHz;
+
+        [SynthDescription("""Blend between dry and filtered signal.""")]
         public float Mix;
+
+        [SynthDescription("""When true, velocity scales the mix amount.""")]
         public bool VelocityAffectsMix;
+
+        [SynthDescription("""Curve for velocity-based mix scaling.""")]
         public Func<float, float>? MixVelocityCurve;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/NoiseGateEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/NoiseGateEffect.cs
@@ -5,6 +5,10 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace klooie;
+[SynthDescription("""
+Suppresses noise by muting the signal below a threshold.
+""")]
+[SynthCategory("Dynamics")]
 class NoiseGateEffect : Recyclable, IEffect
 {
     readonly float[] lookBuf = new float[256];   // ≈ 5.8 ms @44.1 kHz
@@ -21,13 +25,27 @@ class NoiseGateEffect : Recyclable, IEffect
     static readonly LazyPool<NoiseGateEffect> _pool =
         new(() => new NoiseGateEffect());
 
+    [SynthDescription("""
+    Parameters for NoiseGateEffect.
+    """)]
     public struct Settings
     {
+        [SynthDescription("""Threshold for opening the gate.""")]
         public float OpenThresh;
+
+        [SynthDescription("""Threshold for closing the gate.""")]
         public float CloseThresh;
+
+        [SynthDescription("""Attack time in milliseconds.""")]
         public float AttackMs;
+
+        [SynthDescription("""Release time in milliseconds.""")]
         public float ReleaseMs;
+
+        [SynthDescription("""Whether velocity scales the thresholds.""")]
         public bool VelocityAffectsThreshold;
+
+        [SynthDescription("""Curve for velocity-based threshold scaling.""")]
         public Func<float, float>? VelocityCurve;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/ParametricEQEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/ParametricEQEffect.cs
@@ -2,6 +2,10 @@
 
 public enum BiquadType { Peak, LowShelf, HighShelf }
 
+[SynthDescription("""
+Parametric equalizer supporting peak and shelf modes.
+""")]
+[SynthCategory("Filter")]
 public class ParametricEQEffect : Recyclable, IEffect
 {
     // Filter params
@@ -21,14 +25,30 @@ public class ParametricEQEffect : Recyclable, IEffect
 
     private ParametricEQEffect() { }
 
+    [SynthDescription("""
+    Parameters for ParametricEQEffect.
+    """)]
     public struct Settings
     {
+        [SynthDescription("""Type of biquad filter.""")]
         public BiquadType Type;
+
+        [SynthDescription("""Center frequency in Hz.""")]
         public float Freq;
+
+        [SynthDescription("""Gain in decibels.""")]
         public float GainDb;
+
+        [SynthDescription("""Quality factor.""")]
         public float Q;
+
+        [SynthDescription("""Whether velocity affects gain.""")]
         public bool VelocityAffectsGain;
+
+        [SynthDescription("""Curve for velocity-based gain scaling.""")]
         public Func<float, float>? GainVelocityCurve;
+
+        [SynthDescription("""Scale factor for velocity curve.""")]
         public float GainVelocityScale;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/PickTransientEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/PickTransientEffect.cs
@@ -7,6 +7,10 @@ namespace klooie;
 /// Duration & level track the patch’s <c>TransientDurationSeconds</c>.
 /// Place very early in the chain (before distortion) for realism.
 /// </summary>
+[SynthDescription("""
+Adds a short noise transient at note onset for realism.
+""")]
+[SynthCategory("Dynamics")]
 public sealed class PickTransientEffect : Recyclable, IEffect
 {
     private float duration;
@@ -19,9 +23,15 @@ public sealed class PickTransientEffect : Recyclable, IEffect
         new(() => new PickTransientEffect());
     private PickTransientEffect() { rng = new Random(); }
 
+    [SynthDescription("""
+    Parameters for PickTransientEffect.
+    """)]
     public struct Settings
     {
+        [SynthDescription("""Noise duration in seconds.""")]
         public float Duration;
+
+        [SynthDescription("""Amplitude of the transient.""")]
         public float Gain;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/PingPongDelayEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/PingPongDelayEffect.cs
@@ -1,5 +1,9 @@
 ﻿using klooie;
 
+[SynthDescription("""
+Stereo ping-pong delay alternating between left and right channels.
+""")]
+[SynthCategory("Delay")]
 public class PingPongDelayEffect : Recyclable, IEffect
 {
     private float[] leftBuffer, rightBuffer;
@@ -15,12 +19,24 @@ public class PingPongDelayEffect : Recyclable, IEffect
 
     private PingPongDelayEffect() { }
 
+    [SynthDescription("""
+    Parameters for PingPongDelayEffect.
+    """)]
     public struct Settings
     {
+        [SynthDescription("""Delay length in samples.""")]
         public int DelaySamples;
+
+        [SynthDescription("""Feedback amount (0-1).""")]
         public float Feedback;
+
+        [SynthDescription("""Blend between dry and delayed signal (0-1).""")]
         public float Mix;
+
+        [SynthDescription("""Whether velocity scales the mix amount.""")]
         public bool VelocityAffectsMix;
+
+        [SynthDescription("""Curve for velocity-based mix scaling.""")]
         public Func<float, float>? MixVelocityCurve;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/PitchBendEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/PitchBendEffect.cs
@@ -7,6 +7,10 @@ public interface IPitchModEffect : IEffect
 }
 
 
+[SynthDescription("""
+Applies attack and release pitch bends in cents over time.
+""")]
+[SynthCategory("Modulation")]
 public class PitchBendEffect : Recyclable, IPitchModEffect
 {
     private Func<float, float> attackBendFunc;
@@ -18,11 +22,21 @@ public class PitchBendEffect : Recyclable, IPitchModEffect
 
     private PitchBendEffect() { }
 
+    [SynthDescription("""
+    Parameters for PitchBendEffect.
+    """)]
     public struct Settings
     {
+        [SynthDescription("""Function returning pitch offset during attack.""")]
         public Func<float, float> AttackBend;
+
+        [SynthDescription("""Duration of the attack bend in seconds.""")]
         public float AttackDuration;
+
+        [SynthDescription("""Function returning pitch offset during release.""")]
         public Func<float, float> ReleaseBend;
+
+        [SynthDescription("""Duration of the release bend in seconds.""")]
         public float ReleaseDuration;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/PresenceShelfEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/PresenceShelfEffect.cs
@@ -7,6 +7,10 @@ namespace klooie;
 /// Emulates the electrical resonance of passive guitar pickups
 /// and the presence control on high-gain amps.
 /// </summary>
+[SynthDescription("""
+Resonant low-pass feeding a high-shelf booster for presence control.
+""")]
+[SynthCategory("Filter")]
 public sealed class PresenceShelfEffect : Recyclable, IEffect
 {
     /* ---- parameters ---------------------------------------------------- */
@@ -30,10 +34,18 @@ public sealed class PresenceShelfEffect : Recyclable, IEffect
 
     private PresenceShelfEffect() { }
 
+    [SynthDescription("""
+    Parameters for PresenceShelfEffect.
+    """)]
     public struct Settings
     {
+        [SynthDescription("""Amount of high-frequency boost in dB.""")]
         public float PresenceDb;
+
+        [SynthDescription("""Optional curve for velocity-based scaling.""")]
         public Func<float, float>? VelocityCurve;
+
+        [SynthDescription("""Multiplier applied to velocity curve.""")]
         public float VelocityScale;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/ReverbEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/ReverbEffect.cs
@@ -87,6 +87,10 @@ class CombFilter : Recyclable
     }
 }
 
+[SynthDescription("""
+Simple stereo reverb composed of comb and all-pass filters.
+""")]
+[SynthCategory("Reverb")]
 public class ReverbEffect : Recyclable, IEffect
 {
     private CombFilter[] combs;
@@ -101,13 +105,27 @@ public class ReverbEffect : Recyclable, IEffect
 
     private static LazyPool<ReverbEffect> _pool = new(() => new ReverbEffect());
     protected ReverbEffect() { }
+    [SynthDescription("""
+    Parameters for ReverbEffect.
+    """)]
     public struct Settings
     {
+        [SynthDescription("""Feedback amount controlling decay.""")]
         public float Feedback;
+
+        [SynthDescription("""Diffusion amount for all-pass filters.""")]
         public float Diffusion;
+
+        [SynthDescription("""Wet mix level.""")]
         public float Wet;
+
+        [SynthDescription("""Dry signal level.""")]
         public float Dry;
+
+        [SynthDescription("""Whether velocity scales the wet mix.""")]
         public bool VelocityAffectsMix;
+
+        [SynthDescription("""Curve for velocity-based wet scaling.""")]
         public Func<float, float>? MixVelocityCurve;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/StereoChorusEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/StereoChorusEffect.cs
@@ -5,6 +5,10 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace klooie;
+[SynthDescription("""
+Stereo chorus effect with delay modulation.
+""")]
+[SynthCategory("Modulation")]
 public class StereoChorusEffect : Recyclable, IEffect
 {
     private float[] bufferL, bufferR;
@@ -18,13 +22,27 @@ public class StereoChorusEffect : Recyclable, IEffect
 
     private static LazyPool<StereoChorusEffect> _pool = new(() => new StereoChorusEffect());
     protected StereoChorusEffect() { }
+    [SynthDescription("""
+    Parameters for StereoChorusEffect.
+    """)]
     public struct Settings
     {
+        [SynthDescription("""Base delay in milliseconds.""")]
         public int DelayMs;
+
+        [SynthDescription("""Modulation depth in milliseconds.""")]
         public int DepthMs;
+
+        [SynthDescription("""LFO rate in Hz.""")]
         public float RateHz;
+
+        [SynthDescription("""Blend between dry and modulated signal.""")]
         public float Mix;
+
+        [SynthDescription("""Whether velocity scales the mix amount.""")]
         public bool VelocityAffectsMix;
+
+        [SynthDescription("""Curve for velocity-based mix scaling.""")]
         public Func<float, float>? MixVelocityCurve;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/TiltEQEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/TiltEQEffect.cs
@@ -6,6 +6,10 @@ namespace klooie;
 /// First-order tilt-EQ centred around a gentle low-pass.
 /// Positive <c>tilt</c> brightens; negative warms.
 /// </summary>
+[SynthDescription("""
+First-order tilt EQ balancing lows and highs around a fixed cutoff.
+""")]
+[SynthCategory("Filter")]
 public sealed class TiltEQEffect : Recyclable, IEffect
 {
     private float tilt;     // -1 (bass boost) … +1 (treble boost)
@@ -16,9 +20,15 @@ public sealed class TiltEQEffect : Recyclable, IEffect
     private static readonly LazyPool<TiltEQEffect> _pool = new(() => new TiltEQEffect());
     private TiltEQEffect() { }
 
+    [SynthDescription("""
+    Parameters for TiltEQEffect.
+    """)]
     public struct Settings
     {
+        [SynthDescription("""Tilt amount from -1 to +1.""")]
         public float Tilt;
+
+        [SynthDescription("""Cutoff frequency for the underlying low-pass.""")]
         public float CutoffHz;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/ToneStackEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/ToneStackEffect.cs
@@ -10,6 +10,10 @@ namespace klooie;
 /// •  <c>high &gt;  2 500 Hz</c>
 /// Gains are linear (1 = unity, 2 = +6 dB, 0.5 = -6 dB).
 /// </summary>
+[SynthDescription("""
+Classic bass, mid and treble tone stack filter.
+""")]
+[SynthCategory("Filter")]
 public sealed class ToneStackEffect : Recyclable, IEffect
 {
     /* -------------------------------------------------------------------- */
@@ -28,12 +32,24 @@ public sealed class ToneStackEffect : Recyclable, IEffect
         new(() => new ToneStackEffect());
     private ToneStackEffect() { }
 
+    [SynthDescription("""
+    Parameters for ToneStackEffect.
+    """)]
     public struct Settings
     {
+        [SynthDescription("""Bass gain factor.""")]
         public float Bass;
+
+        [SynthDescription("""Mid gain factor.""")]
         public float Mid;
+
+        [SynthDescription("""Treble gain factor.""")]
         public float Treble;
+
+        [SynthDescription("""Whether velocity scales all gains.""")]
         public bool VelocityAffectsGain;
+
+        [SynthDescription("""Curve for velocity-based gain scaling.""")]
         public Func<float, float>? GainVelocityCurve;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/TremoloEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/TremoloEffect.cs
@@ -1,6 +1,10 @@
 using System;
 
 namespace klooie;
+[SynthDescription("""
+Amplitude tremolo modulation.
+""")]
+[SynthCategory("Modulation")]
 public class TremoloEffect : Recyclable, IEffect
 {
     private float depth;
@@ -12,11 +16,21 @@ public class TremoloEffect : Recyclable, IEffect
     private static readonly LazyPool<TremoloEffect> _pool = new(() => new TremoloEffect());
     protected TremoloEffect() { }
 
+    [SynthDescription("""
+    Parameters for TremoloEffect.
+    """)]
     public struct Settings
     {
+        [SynthDescription("""Depth of modulation (0-1).""")]
         public float Depth;
+
+        [SynthDescription("""LFO rate in Hz.""")]
         public float RateHz;
+
+        [SynthDescription("""When true, velocity scales the modulation depth.""")]
         public bool VelocityAffectsDepth;
+
+        [SynthDescription("""Curve for velocity-based depth scaling.""")]
         public Func<float, float>? DepthVelocityCurve;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/VolumeEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/VolumeEffect.cs
@@ -9,6 +9,10 @@ namespace klooie;
 /// Scales the input by a constant gain and optionally modulates that gain with
 /// note velocity.
 /// </summary>
+[SynthDescription("""
+Simple gain stage with optional velocity modulation.
+""")]
+[SynthCategory("Utility")]
 public class VolumeEffect : Recyclable, IEffect
 {
     private float gain;
@@ -18,10 +22,18 @@ public class VolumeEffect : Recyclable, IEffect
     private VolumeEffect() { }
     static readonly LazyPool<VolumeEffect> _pool = new(() => new VolumeEffect());
 
+[SynthDescription("""
+Parameters for VolumeEffect.
+""")]
 public struct Settings
 {
+    [SynthDescription("""Gain multiplier.""")]
     public float Gain;
+
+    [SynthDescription("""Curve mapping velocity to a scale factor.""")]
     public Func<float, float>? VelocityCurve;
+
+    [SynthDescription("""Multiplier applied to the velocity curve.""")]
     public float VelocityScale;
 }
 

--- a/src/klooie/Audio/SignalProcessing/SynthDocAttributes.cs
+++ b/src/klooie/Audio/SignalProcessing/SynthDocAttributes.cs
@@ -1,0 +1,15 @@
+namespace klooie;
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Field)]
+public sealed class SynthDescriptionAttribute : Attribute
+{
+    public string Description { get; }
+    public SynthDescriptionAttribute(string description) => Description = description;
+}
+
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class SynthCategoryAttribute : Attribute
+{
+    public string Category { get; }
+    public SynthCategoryAttribute(string category) => Category = category;
+}

--- a/src/klooie/Audio/SignalProcessing/SynthDocGenerator.cs
+++ b/src/klooie/Audio/SignalProcessing/SynthDocGenerator.cs
@@ -1,0 +1,74 @@
+using System.Reflection;
+using System.Text;
+
+namespace klooie;
+
+public static class SynthDocGenerator
+{
+    private record FieldDoc(string Name, string Description);
+    private record ParamDoc(string Name, string Description, List<FieldDoc> Fields);
+    private record EffectDoc(string Category, string Name, string Description, ParamDoc? Params);
+
+    public static string GenerateMarkdown()
+    {
+        var effectType = typeof(IEffect);
+        var allTypes = AppDomain.CurrentDomain.GetAssemblies()
+            .SelectMany(a => a.GetTypes());
+
+        var effects = new List<EffectDoc>();
+
+        foreach (var type in allTypes)
+        {
+            if (!effectType.IsAssignableFrom(type) || type.IsAbstract || type.IsInterface)
+                continue;
+
+            var desc = type.GetCustomAttribute<SynthDescriptionAttribute>();
+            var cat = type.GetCustomAttribute<SynthCategoryAttribute>();
+            if (desc == null || cat == null)
+                continue;
+
+            ParamDoc? paramDoc = null;
+            var paramType = type.GetNestedTypes(BindingFlags.Public | BindingFlags.NonPublic)
+                .FirstOrDefault(t => t.IsValueType && t.GetCustomAttribute<SynthDescriptionAttribute>() != null);
+            if (paramType != null)
+            {
+                var pDesc = paramType.GetCustomAttribute<SynthDescriptionAttribute>()!.Description;
+                var fields = new List<FieldDoc>();
+                foreach (var field in paramType.GetFields(BindingFlags.Public | BindingFlags.Instance))
+                {
+                    var fDesc = field.GetCustomAttribute<SynthDescriptionAttribute>()?.Description ?? "No description.";
+                    fields.Add(new FieldDoc(field.Name, fDesc));
+                }
+                paramDoc = new ParamDoc(paramType.Name, pDesc, fields);
+            }
+
+            effects.Add(new EffectDoc(cat.Category, type.Name, desc.Description, paramDoc));
+        }
+
+        var sb = new StringBuilder();
+        foreach (var group in effects.GroupBy(e => e.Category).OrderBy(g => g.Key))
+        {
+            sb.AppendLine($"# {group.Key}");
+            sb.AppendLine();
+            foreach (var effect in group.OrderBy(e => e.Name))
+            {
+                sb.AppendLine($"## {effect.Name}");
+                sb.AppendLine(effect.Description);
+                sb.AppendLine();
+                if (effect.Params != null)
+                {
+                    sb.AppendLine($"### {effect.Params.Name}");
+                    sb.AppendLine(effect.Params.Description);
+                    sb.AppendLine();
+                    sb.AppendLine("| Field | Description |");
+                    sb.AppendLine("|-------|-------------|");
+                    foreach (var field in effect.Params.Fields)
+                        sb.AppendLine($"| `{field.Name}` | {field.Description} |");
+                    sb.AppendLine();
+                }
+            }
+        }
+
+        return sb.ToString();
+    }
+}


### PR DESCRIPTION
## Summary
- add `SynthDescription` and `SynthCategory` annotations to every effect class
- document all parameter structs and fields
- keep generator that scans effects and outputs Markdown

## Testing
- `dotnet build src/klooie/klooie.csproj -c Release` *(fails: command not found)*
- `dotnet test src/tests/tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a6a1225cc8325a4536d380592846e