### PR TITLE
Add Synth Patch Metadata

### DIFF
--- a/src/klooie/Audio/SignalProcessing/Patches/AmpedRockGuitarPatch.cs
+++ b/src/klooie/Audio/SignalProcessing/Patches/AmpedRockGuitarPatch.cs
@@ -2,11 +2,11 @@
 
 namespace klooie;
 
-/// <summary>
-/// Modern high-gain guitar “amp-stack”:
-///   pre-HPF → pre-gain → AggroDistortion → Tone Stack → 4×12 cab →
-///   LPF fizz-tamer → compressor → width / ambience.
-/// </summary>
+[SynthCategory("Guitar")]
+[SynthDescription("""
+High-gain guitar patch built from stacked distortion, tone shaping,
+cabinet simulation and ambience effects for aggressive rock lines.
+""")]
 public sealed class AmpedRockGuitarPatch : Recyclable, ISynthPatch, ICompositePatch
 {
     /* -------------------------------------------------------------------- */

--- a/src/klooie/Audio/SignalProcessing/Patches/LayeredPatch.cs
+++ b/src/klooie/Audio/SignalProcessing/Patches/LayeredPatch.cs
@@ -1,5 +1,10 @@
 ﻿using klooie;
 
+[SynthCategory("Utility")]
+[SynthDescription("""
+Combines multiple patches into layers with per-layer volume, pan and
+transpose control for complex instruments.
+""")]
 public sealed class LayeredPatch : Recyclable, ISynthPatch, ICompositePatch
 {
     private ISynthPatch[] layers;
@@ -108,5 +113,23 @@ public sealed class LayeredPatch : Recyclable, ISynthPatch, ICompositePatch
         layerPans = null!;
         layerTransposes = null!;
         base.OnReturn();
+    }
+
+    [SynthDescription("""
+    Parameters controlling how patches are layered.
+    """)]
+    public struct Settings
+    {
+        [SynthDescription("""Patches to layer together.""")]
+        public ISynthPatch[] Patches;
+
+        [SynthDescription("""Relative volume for each layer (0–1).""")]
+        public float[]? Volumes;
+
+        [SynthDescription("""Pan position per layer (-1 = left, +1 = right).""")]
+        public float[]? Pans;
+
+        [SynthDescription("""Semitone offset applied to each layer.""")]
+        public int[]? Transposes;
     }
 }

--- a/src/klooie/Audio/SignalProcessing/Patches/PowerChordPatch.cs
+++ b/src/klooie/Audio/SignalProcessing/Patches/PowerChordPatch.cs
@@ -5,6 +5,11 @@ using System.Reflection;
 
 namespace klooie;
 
+[SynthCategory("Utility")]
+[SynthDescription("""
+Layers transposed copies of a base patch to form power chords with
+adjustable detune and stereo spread.
+""")]
 public class PowerChordPatch : Recyclable, ISynthPatch, ICompositePatch
 {
     private ISynthPatch basePatch;
@@ -138,5 +143,23 @@ public class PowerChordPatch : Recyclable, ISynthPatch, ICompositePatch
         detuneCents = 0f;
         panSpread = 0f;
         patches = null;
+    }
+
+    [SynthDescription("""
+    Settings used to build a power-chord patch.
+    """)]
+    public struct Settings
+    {
+        [SynthDescription("""Patch to duplicate for each chord note.""")]
+        public ISynthPatch BasePatch;
+
+        [SynthDescription("""Semitone offsets for each additional note.""")]
+        public int[]? Intervals;
+
+        [SynthDescription("""Maximum detune spread in cents.""")]
+        public float DetuneCents;
+
+        [SynthDescription("""Stereo spread of layers (-1 to 1).""")]
+        public float PanSpread;
     }
 }

--- a/src/klooie/Audio/SignalProcessing/Patches/RockGuitar2.cs
+++ b/src/klooie/Audio/SignalProcessing/Patches/RockGuitar2.cs
@@ -2,6 +2,11 @@
 
 namespace klooie;
 
+[SynthCategory("Guitar")]
+[SynthDescription("""
+Moderate-gain rock guitar patch featuring layered unison voices and
+power-chord assembly for realistic riffs.
+""")]
 public sealed class RockGuitar2 : Recyclable, ISynthPatch, ICompositePatch
 {
     public bool IsNotePlayable(int midiNote) => midiNote >= 37 && midiNote <= 60;

--- a/src/klooie/Audio/SignalProcessing/Patches/SynthPatch.cs
+++ b/src/klooie/Audio/SignalProcessing/Patches/SynthPatch.cs
@@ -34,6 +34,11 @@ public interface ISynthPatch
     void SpawnVoices(float frequencyHz, VolumeKnob master, NoteExpression note, List<SynthSignalSource> outVoices);
 }
 
+[SynthCategory("Core")]
+[SynthDescription("""
+Basic synthesizer patch providing a single oscillator with optional
+sub oscillator, vibrato, pitch drift and effect chain support.
+""")]
 public class SynthPatch : Recyclable, ISynthPatch
 {
     public ISynthPatch InnerPatch => this;

--- a/src/klooie/Audio/SignalProcessing/Patches/UnisonPatch.cs
+++ b/src/klooie/Audio/SignalProcessing/Patches/UnisonPatch.cs
@@ -6,6 +6,11 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace klooie;
+[SynthCategory("Utility")]
+[SynthDescription("""
+Creates multiple detuned copies of a patch for wide, thick sounds
+with controllable pan spread.
+""")]
 public class UnisonPatch : Recyclable, ISynthPatch, ICompositePatch
 {
     private ISynthPatch basePatch;
@@ -131,5 +136,23 @@ public class UnisonPatch : Recyclable, ISynthPatch, ICompositePatch
         detuneCents = 0f;
         panSpread = 0f;
         _innerPatches = null!;
+    }
+
+    [SynthDescription("""
+    Parameters for creating a unison patch.
+    """)]
+    public struct Settings
+    {
+        [SynthDescription("""Patch to clone for each voice.""")]
+        public ISynthPatch BasePatch;
+
+        [SynthDescription("""Number of detuned voices.""")]
+        public int NumVoices;
+
+        [SynthDescription("""Total detune range in cents.""")]
+        public float DetuneCents;
+
+        [SynthDescription("""Stereo spread of the voices (-1 to 1).""")]
+        public float PanSpread;
     }
 }


### PR DESCRIPTION
## Summary
- add `SynthCategory` and `SynthDescription` metadata to all patch classes
- document patch configuration fields

## Testing
- `dotnet test --no-build -v minimal src/tests/tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a751c5e588325b5bbde3387304d2f