### PR TITLE
Fix SynthDescription raw string formatting

### DIFF
--- a/src/klooie/Audio/SignalProcessing/Effects/AggroDistortionEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/AggroDistortionEffect.cs
@@ -30,29 +30,39 @@ public sealed class AggroDistortionEffect : Recyclable, IEffect
     private AggroDistortionEffect() { }
 
     [SynthDescription("""
-    Settings used when constructing an AggroDistortionEffect.  These values
-    control how hard the signal is driven and how each stage behaves.
-    """)]
+Settings used when constructing an AggroDistortionEffect.  These values
+control how hard the signal is driven and how each stage behaves.
+""")]
     public struct Settings
     {
-        [SynthDescription("""Pre-gain applied before the distortion stages.  Higher
-        values push the effect harder.""")]
+        [SynthDescription("""
+Pre-gain applied before the distortion stages.  Higher
+values push the effect harder.
+""")]
         public float Drive;
 
-        [SynthDescription("""Relative gain drop applied to each successive
-        distortion stage.""")]
+        [SynthDescription("""
+Relative gain drop applied to each successive
+distortion stage.
+""")]
         public float StageRatio;
 
-        [SynthDescription("""Offset that introduces asymmetry into the clipping
-        curve.""")]
+        [SynthDescription("""
+Offset that introduces asymmetry into the clipping
+curve.
+""")]
         public float Bias;
 
-        [SynthDescription("""Function mapping note velocity to a gain
-        multiplier.""")]
+        [SynthDescription("""
+Function mapping note velocity to a gain
+multiplier.
+""")]
         public Func<float, float>? VelocityCurve;
 
-        [SynthDescription("""Overall multiplier applied after evaluating the
-        velocity curve.""")]
+        [SynthDescription("""
+Overall multiplier applied after evaluating the
+velocity curve.
+""")]
         public float VelocityScale;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/CabinetEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/CabinetEffect.cs
@@ -24,17 +24,21 @@ class CabinetEffect : Recyclable, IEffect
         new(() => new CabinetEffect());
 
     [SynthDescription("""
-    Settings controlling the cabinet simulation.  These include an optional
-    curve for scaling output based on note velocity.
-    """)]
+Settings controlling the cabinet simulation.  These include an optional
+curve for scaling output based on note velocity.
+""")]
     public struct Settings
     {
-        [SynthDescription("""Function that adjusts output level based on the
-        note's velocity.""")]
+        [SynthDescription("""
+Function that adjusts output level based on the
+note's velocity.
+""")]
         public Func<float, float>? VelocityCurve;
 
-        [SynthDescription("""Additional multiplier applied after evaluating the
-        velocity curve.""")]
+        [SynthDescription("""
+Additional multiplier applied after evaluating the
+velocity curve.
+""")]
         public float VelocityScale;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/CompressorEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/CompressorEffect.cs
@@ -30,31 +30,43 @@ public sealed class CompressorEffect : Recyclable, IEffect
     private CompressorEffect() { }
 
     [SynthDescription("""
-    Settings that define how the compressor reacts to incoming audio.
-    """)]
+Settings that define how the compressor reacts to incoming audio.
+""")]
     public struct Settings
     {
-        [SynthDescription("""Input level (0–1) above which compression begins.""")]
+        [SynthDescription("""
+Input level (0–1) above which compression begins.
+""")]
         public float Threshold;
 
-        [SynthDescription("""Amount of gain reduction applied once above the
-        threshold.""")]
+        [SynthDescription("""
+Amount of gain reduction applied once above the
+threshold.
+""")]
         public float Ratio;
 
-        [SynthDescription("""How quickly the compressor engages when the
-        threshold is exceeded.""")]
+        [SynthDescription("""
+How quickly the compressor engages when the
+threshold is exceeded.
+""")]
         public float Attack;
 
-        [SynthDescription("""How quickly the compression relaxes after the
-        signal falls below the threshold.""")]
+        [SynthDescription("""
+How quickly the compression relaxes after the
+signal falls below the threshold.
+""")]
         public float Release;
 
-        [SynthDescription("""Function mapping note velocity to a gain
-        multiplier.""")]
+        [SynthDescription("""
+Function mapping note velocity to a gain
+multiplier.
+""")]
         public Func<float, float>? VelocityCurve;
 
-        [SynthDescription("""Multiplier applied after evaluating the velocity
-        curve.""")]
+        [SynthDescription("""
+Multiplier applied after evaluating the velocity
+curve.
+""")]
         public float VelocityScale;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/DCBlockerEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/DCBlockerEffect.cs
@@ -26,17 +26,21 @@ public sealed class DCBlockerEffect : Recyclable, IEffect
     private DCBlockerEffect() { }
 
     [SynthDescription("""
-    Configuration options for the DC blocker including optional velocity
-    sensitivity.
-    """)]
+Configuration options for the DC blocker including optional velocity
+sensitivity.
+""")]
     public struct Settings
     {
-        [SynthDescription("""When true, the output level is scaled by the
-        incoming note velocity.""")]
+        [SynthDescription("""
+When true, the output level is scaled by the
+incoming note velocity.
+""")]
         public bool VelocityAffectsOutput;
 
-        [SynthDescription("""Function applied to velocity when computing the
-        output scale.""")]
+        [SynthDescription("""
+Function applied to velocity when computing the
+output scale.
+""")]
         public Func<float, float>? VelocityCurve;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/DelayEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/DelayEffect.cs
@@ -23,28 +23,38 @@ public class DelayEffect : Recyclable, IEffect
     protected DelayEffect() { }
 
     [SynthDescription("""
-    Settings for constructing a DelayEffect.  DelaySamples is specified in
-    audio samples while the other values range between 0 and 1.
-    """)]
+Settings for constructing a DelayEffect.  DelaySamples is specified in
+audio samples while the other values range between 0 and 1.
+""")]
     public struct Settings
     {
-        [SynthDescription("""Length of the delay buffer measured in samples.""")]
+        [SynthDescription("""
+Length of the delay buffer measured in samples.
+""")]
         public int DelaySamples;
 
-        [SynthDescription("""Fraction of the delayed output that is fed back for
-        repeated echoes (0 = none, 1 = infinite).""")]
+        [SynthDescription("""
+Fraction of the delayed output that is fed back for
+repeated echoes (0 = none, 1 = infinite).
+""")]
         public float Feedback;
 
-        [SynthDescription("""Mix between the original signal and the delayed
-        signal. 0 gives only the dry signal, 1 gives only delay.""")]
+        [SynthDescription("""
+Mix between the original signal and the delayed
+signal. 0 gives only the dry signal, 1 gives only delay.
+""")]
         public float Mix;
 
-        [SynthDescription("""When true, harder played notes increase the mix
-        amount.""")]
+        [SynthDescription("""
+When true, harder played notes increase the mix
+amount.
+""")]
         public bool VelocityAffectsMix;
 
-        [SynthDescription("""Function that converts normalized velocity into a
-        multiplier applied to the mix.""")]
+        [SynthDescription("""
+Function that converts normalized velocity into a
+multiplier applied to the mix.
+""")]
         public Func<float, float>? MixVelocityCurve;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/DistortionEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/DistortionEffect.cs
@@ -25,29 +25,39 @@ class DistortionEffect : Recyclable, IEffect
     static readonly LazyPool<DistortionEffect> _pool = new(() => new DistortionEffect());
 
     [SynthDescription("""
-    Settings used to build a DistortionEffect.  They define the drive level and
-    how each clipping stage behaves.
-    """)]
+Settings used to build a DistortionEffect.  They define the drive level and
+how each clipping stage behaves.
+""")]
     public struct Settings
     {
-        [SynthDescription("""Gain applied before the first clipping stage.  Higher
-        values yield more distortion.""")]
+        [SynthDescription("""
+Gain applied before the first clipping stage.  Higher
+values yield more distortion.
+""")]
         public float Drive;
 
-        [SynthDescription("""Multiplier controlling how much the gain decreases
-        at each successive stage.""")]
+        [SynthDescription("""
+Multiplier controlling how much the gain decreases
+at each successive stage.
+""")]
         public float StageRatio;
 
-        [SynthDescription("""Offset added before clipping to produce asymmetric
-        distortion.""")]
+        [SynthDescription("""
+Offset added before clipping to produce asymmetric
+distortion.
+""")]
         public float Bias;
 
-        [SynthDescription("""Optional function mapping note velocity to a gain
-        multiplier.""")]
+        [SynthDescription("""
+Optional function mapping note velocity to a gain
+multiplier.
+""")]
         public Func<float, float>? VelocityCurve;
 
-        [SynthDescription("""Additional multiplier applied after evaluating the
-        velocity curve.""")]
+        [SynthDescription("""
+Additional multiplier applied after evaluating the
+velocity curve.
+""")]
         public float VelocityScale;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/EnvelopeEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/EnvelopeEffect.cs
@@ -19,22 +19,30 @@ public class EnvelopeEffect : Recyclable, IEffect
     private EnvelopeEffect() { }
 
     [SynthDescription("""
-    Timing values used to construct the ADSR envelope.
-    """)]
+Timing values used to construct the ADSR envelope.
+""")]
     public struct Settings
     {
-        [SynthDescription("""Duration of the attack phase in seconds.""")]
+        [SynthDescription("""
+Duration of the attack phase in seconds.
+""")]
         public double Attack;
 
-        [SynthDescription("""Time for the level to drop from the peak to the
-        sustain level.""")]
+        [SynthDescription("""
+Time for the level to drop from the peak to the
+sustain level.
+""")]
         public double Decay;
 
-        [SynthDescription("""Normalized sustain level (0–1) held until release.""")]
+        [SynthDescription("""
+Normalized sustain level (0–1) held until release.
+""")]
         public double Sustain;
 
-        [SynthDescription("""Time for the level to fade out after a note is
-        released.""")]
+        [SynthDescription("""
+Time for the level to fade out after a note is
+released.
+""")]
         public double Release;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/Fade.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/Fade.cs
@@ -24,20 +24,26 @@ public class FadeInEffect : Recyclable, IEffect
     private FadeInEffect() { }
 
     [SynthDescription("""
-    Settings controlling the duration of the fade‑in and optional velocity
-    modulation.
-    """)]
+Settings controlling the duration of the fade‑in and optional velocity
+modulation.
+""")]
     public struct Settings
     {
-        [SynthDescription("""How long the fade‑in lasts, measured in seconds.""")]
+        [SynthDescription("""
+How long the fade‑in lasts, measured in seconds.
+""")]
         public float DurationSeconds;
 
-        [SynthDescription("""Function that maps note velocity to an additional
-        gain multiplier.""")]
+        [SynthDescription("""
+Function that maps note velocity to an additional
+gain multiplier.
+""")]
         public Func<float, float>? VelocityCurve;
 
-        [SynthDescription("""Multiplier applied after evaluating the velocity
-        curve.""")]
+        [SynthDescription("""
+Multiplier applied after evaluating the velocity
+curve.
+""")]
         public float VelocityScale;
     }
 
@@ -118,18 +124,26 @@ velocity scaling.
 """)]
 public struct Settings
 {
-    [SynthDescription("""Length of the fade‑out in seconds.""")]
+    [SynthDescription("""
+Length of the fade‑out in seconds.
+""")]
     public float DurationSeconds;
 
-    [SynthDescription("""Time in seconds when the fade‑out begins.""")]
+    [SynthDescription("""
+Time in seconds when the fade‑out begins.
+""")]
     public float FadeStartTime;
 
-    [SynthDescription("""Function mapping note velocity to a gain factor
-    applied during the fade.""")]
+    [SynthDescription("""
+Function mapping note velocity to a gain factor
+applied during the fade.
+""")]
     public Func<float, float>? VelocityCurve;
 
-    [SynthDescription("""Multiplier applied to the result of the velocity
-    curve.""")]
+    [SynthDescription("""
+Multiplier applied to the result of the velocity
+curve.
+""")]
     public float VelocityScale;
 }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/HighPassFilterEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/HighPassFilterEffect.cs
@@ -19,25 +19,33 @@ public class HighPassFilterEffect : Recyclable, IEffect
     protected HighPassFilterEffect() { }
 
     [SynthDescription("""
-    Settings describing the cutoff frequency and how the mix reacts to
-    note velocity.
-    """)]
+Settings describing the cutoff frequency and how the mix reacts to
+note velocity.
+""")]
     public struct Settings
     {
-        [SynthDescription("""Frequency above which audio passes through,
-        measured in hertz.""")]
+        [SynthDescription("""
+Frequency above which audio passes through,
+measured in hertz.
+""")]
         public float CutoffHz;
 
-        [SynthDescription("""Amount of filtered signal mixed with the original
-        (0 = dry, 1 = fully filtered).""")]
+        [SynthDescription("""
+Amount of filtered signal mixed with the original
+(0 = dry, 1 = fully filtered).
+""")]
         public float Mix;
 
-        [SynthDescription("""When true, harder played notes increase the mix of
-        the filtered signal.""")]
+        [SynthDescription("""
+When true, harder played notes increase the mix of
+the filtered signal.
+""")]
         public bool VelocityAffectsMix;
 
-        [SynthDescription("""Function mapping normalized velocity to a
-        mix multiplier.""")]
+        [SynthDescription("""
+Function mapping normalized velocity to a
+mix multiplier.
+""")]
         public Func<float, float>? MixVelocityCurve;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/LowPassFilterEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/LowPassFilterEffect.cs
@@ -23,25 +23,33 @@ class LowPassFilterEffect : Recyclable, IEffect
     private LowPassFilterEffect() { }
 
     [SynthDescription("""
-    Settings describing the cutoff frequency and how strongly the filtered
-    signal is mixed in.
-    """)]
+Settings describing the cutoff frequency and how strongly the filtered
+signal is mixed in.
+""")]
     public struct Settings
     {
-        [SynthDescription("""Cutoff frequency in hertz above which the signal is
-        attenuated.""")]
+        [SynthDescription("""
+Cutoff frequency in hertz above which the signal is
+attenuated.
+""")]
         public float CutoffHz;
 
-        [SynthDescription("""Mix level between the original and filtered signal
-        (0 = dry, 1 = filtered).""")]
+        [SynthDescription("""
+Mix level between the original and filtered signal
+(0 = dry, 1 = filtered).
+""")]
         public float Mix;
 
-        [SynthDescription("""If true, note velocity changes how much of the
-        filtered signal is heard.""")]
+        [SynthDescription("""
+If true, note velocity changes how much of the
+filtered signal is heard.
+""")]
         public bool VelocityAffectsMix;
 
-        [SynthDescription("""Function converting velocity into a mix
-        multiplier.""")]
+        [SynthDescription("""
+Function converting velocity into a mix
+multiplier.
+""")]
         public Func<float, float>? MixVelocityCurve;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/NoiseGateEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/NoiseGateEffect.cs
@@ -27,28 +27,40 @@ class NoiseGateEffect : Recyclable, IEffect
         new(() => new NoiseGateEffect());
 
     [SynthDescription("""
-    Settings that determine how the gate opens and closes.
-    """)]
+Settings that determine how the gate opens and closes.
+""")]
     public struct Settings
     {
-        [SynthDescription("""Signal level above which the gate opens.""")]
+        [SynthDescription("""
+Signal level above which the gate opens.
+""")]
         public float OpenThresh;
 
-        [SynthDescription("""Level below which the gate starts to close.""")]
+        [SynthDescription("""
+Level below which the gate starts to close.
+""")]
         public float CloseThresh;
 
-        [SynthDescription("""Time in milliseconds for the gate to fully open""")]
+        [SynthDescription("""
+Time in milliseconds for the gate to fully open
+""")]
         public float AttackMs;
 
-        [SynthDescription("""Time in milliseconds for the gate to fully close""")]
+        [SynthDescription("""
+Time in milliseconds for the gate to fully close
+""")]
         public float ReleaseMs;
 
-        [SynthDescription("""If true, note velocity scales the open and close
-        thresholds.""")]
+        [SynthDescription("""
+If true, note velocity scales the open and close
+thresholds.
+""")]
         public bool VelocityAffectsThreshold;
 
-        [SynthDescription("""Function that maps velocity to a multiplier used
-        when scaling the thresholds.""")]
+        [SynthDescription("""
+Function that maps velocity to a multiplier used
+when scaling the thresholds.
+""")]
         public Func<float, float>? VelocityCurve;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/ParametricEQEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/ParametricEQEffect.cs
@@ -26,33 +26,47 @@ public class ParametricEQEffect : Recyclable, IEffect
     private ParametricEQEffect() { }
 
     [SynthDescription("""
-    Settings that configure the filter type, frequency and how gain responds to
-    note velocity.
-    """)]
+Settings that configure the filter type, frequency and how gain responds to
+note velocity.
+""")]
     public struct Settings
     {
-        [SynthDescription("""Which biquad filter to use (peak, low shelf or high
-        shelf).""")]
+        [SynthDescription("""
+Which biquad filter to use (peak, low shelf or high
+shelf).
+""")]
         public BiquadType Type;
 
-        [SynthDescription("""Center frequency in hertz.""")]
+        [SynthDescription("""
+Center frequency in hertz.
+""")]
         public float Freq;
 
-        [SynthDescription("""Boost or cut amount in decibels.""")]
+        [SynthDescription("""
+Boost or cut amount in decibels.
+""")]
         public float GainDb;
 
-        [SynthDescription("""Resonance or bandwidth of the filter.""")]
+        [SynthDescription("""
+Resonance or bandwidth of the filter.
+""")]
         public float Q;
 
-        [SynthDescription("""If true, note velocity modulates the filter's
-        gain.""")]
+        [SynthDescription("""
+If true, note velocity modulates the filter's
+gain.
+""")]
         public bool VelocityAffectsGain;
 
-        [SynthDescription("""Function mapping velocity to a gain multiplier.""")]
+        [SynthDescription("""
+Function mapping velocity to a gain multiplier.
+""")]
         public Func<float, float>? GainVelocityCurve;
 
-        [SynthDescription("""Multiplier applied after evaluating the velocity
-        curve.""")]
+        [SynthDescription("""
+Multiplier applied after evaluating the velocity
+curve.
+""")]
         public float GainVelocityScale;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/PickTransientEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/PickTransientEffect.cs
@@ -25,14 +25,18 @@ public sealed class PickTransientEffect : Recyclable, IEffect
     private PickTransientEffect() { rng = new Random(); }
 
     [SynthDescription("""
-    Settings controlling how long the noise burst lasts and how loud it is.
-    """)]
+Settings controlling how long the noise burst lasts and how loud it is.
+""")]
     public struct Settings
     {
-        [SynthDescription("""Length of the noise burst in seconds.""")]
+        [SynthDescription("""
+Length of the noise burst in seconds.
+""")]
         public float Duration;
 
-        [SynthDescription("""Volume of the transient noise.""")]
+        [SynthDescription("""
+Volume of the transient noise.
+""")]
         public float Gain;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/PingPongDelayEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/PingPongDelayEffect.cs
@@ -21,27 +21,37 @@ public class PingPongDelayEffect : Recyclable, IEffect
     private PingPongDelayEffect() { }
 
     [SynthDescription("""
-    Settings that define the delay time, feedback and how the echoes mix with
-    the original signal.
-    """)]
+Settings that define the delay time, feedback and how the echoes mix with
+the original signal.
+""")]
     public struct Settings
     {
-        [SynthDescription("""Length of the delay line in samples.""")]
+        [SynthDescription("""
+Length of the delay line in samples.
+""")]
         public int DelaySamples;
 
-        [SynthDescription("""Portion of the delayed signal fed back for more
-        repeats (0 = none, 1 = infinite).""")]
+        [SynthDescription("""
+Portion of the delayed signal fed back for more
+repeats (0 = none, 1 = infinite).
+""")]
         public float Feedback;
 
-        [SynthDescription("""Mix between original and delayed signals (0 = dry,
-        1 = fully wet).""")]
+        [SynthDescription("""
+Mix between original and delayed signals (0 = dry,
+1 = fully wet).
+""")]
         public float Mix;
 
-        [SynthDescription("""If true, harder notes produce a stronger delay
-        mix.""")]
+        [SynthDescription("""
+If true, harder notes produce a stronger delay
+mix.
+""")]
         public bool VelocityAffectsMix;
 
-        [SynthDescription("""Function mapping velocity to a mix multiplier.""")]
+        [SynthDescription("""
+Function mapping velocity to a mix multiplier.
+""")]
         public Func<float, float>? MixVelocityCurve;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/PitchBendEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/PitchBendEffect.cs
@@ -24,22 +24,30 @@ public class PitchBendEffect : Recyclable, IPitchModEffect
     private PitchBendEffect() { }
 
     [SynthDescription("""
-    Functions and timing values defining the attack and release pitch bends.
-    """)]
+Functions and timing values defining the attack and release pitch bends.
+""")]
     public struct Settings
     {
-        [SynthDescription("""Function that returns a pitch offset (in cents)
-        over the course of the attack.""")]
+        [SynthDescription("""
+Function that returns a pitch offset (in cents)
+over the course of the attack.
+""")]
         public Func<float, float> AttackBend;
 
-        [SynthDescription("""Length of the attack bend in seconds.""")]
+        [SynthDescription("""
+Length of the attack bend in seconds.
+""")]
         public float AttackDuration;
 
-        [SynthDescription("""Function providing the pitch offset curve during
-        the release phase.""")]
+        [SynthDescription("""
+Function providing the pitch offset curve during
+the release phase.
+""")]
         public Func<float, float> ReleaseBend;
 
-        [SynthDescription("""Length of the release bend in seconds.""")]
+        [SynthDescription("""
+Length of the release bend in seconds.
+""")]
         public float ReleaseDuration;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/PresenceShelfEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/PresenceShelfEffect.cs
@@ -36,20 +36,26 @@ public sealed class PresenceShelfEffect : Recyclable, IEffect
     private PresenceShelfEffect() { }
 
     [SynthDescription("""
-    Settings controlling the amount of high-frequency boost and optional
-    velocity-based scaling.
-    """)]
+Settings controlling the amount of high-frequency boost and optional
+velocity-based scaling.
+""")]
     public struct Settings
     {
-        [SynthDescription("""Boost applied to the high frequencies in decibels.""")]
+        [SynthDescription("""
+Boost applied to the high frequencies in decibels.
+""")]
         public float PresenceDb;
 
-        [SynthDescription("""Function used to scale the boost based on note
-        velocity.""")]
+        [SynthDescription("""
+Function used to scale the boost based on note
+velocity.
+""")]
         public Func<float, float>? VelocityCurve;
 
-        [SynthDescription("""Additional multiplier applied to the velocity
-        curve's output.""")]
+        [SynthDescription("""
+Additional multiplier applied to the velocity
+curve's output.
+""")]
         public float VelocityScale;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/ReverbEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/ReverbEffect.cs
@@ -107,31 +107,43 @@ public class ReverbEffect : Recyclable, IEffect
     private static LazyPool<ReverbEffect> _pool = new(() => new ReverbEffect());
     protected ReverbEffect() { }
     [SynthDescription("""
-    Settings controlling reverb decay, diffusion and how the wet/dry mix reacts
-    to note velocity.
-    """)]
+Settings controlling reverb decay, diffusion and how the wet/dry mix reacts
+to note velocity.
+""")]
     public struct Settings
     {
-        [SynthDescription("""Amount of feedback which determines how long the
-        reverb tail lasts.""")]
+        [SynthDescription("""
+Amount of feedback which determines how long the
+reverb tail lasts.
+""")]
         public float Feedback;
 
-        [SynthDescription("""How dense the reflections become. Higher values
-        create a smoother tail.""")]
+        [SynthDescription("""
+How dense the reflections become. Higher values
+create a smoother tail.
+""")]
         public float Diffusion;
 
-        [SynthDescription("""Volume of the reverberated (wet) signal.""")]
+        [SynthDescription("""
+Volume of the reverberated (wet) signal.
+""")]
         public float Wet;
 
-        [SynthDescription("""Volume of the unaffected (dry) signal.""")]
+        [SynthDescription("""
+Volume of the unaffected (dry) signal.
+""")]
         public float Dry;
 
-        [SynthDescription("""If true, note velocity influences the wet mix
-        level.""")]
+        [SynthDescription("""
+If true, note velocity influences the wet mix
+level.
+""")]
         public bool VelocityAffectsMix;
 
-        [SynthDescription("""Function mapping velocity to a multiplier applied
-        to the wet level.""")]
+        [SynthDescription("""
+Function mapping velocity to a multiplier applied
+to the wet level.
+""")]
         public Func<float, float>? MixVelocityCurve;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/StereoChorusEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/StereoChorusEffect.cs
@@ -24,28 +24,40 @@ public class StereoChorusEffect : Recyclable, IEffect
     private static LazyPool<StereoChorusEffect> _pool = new(() => new StereoChorusEffect());
     protected StereoChorusEffect() { }
     [SynthDescription("""
-    Settings defining the base delay time, modulation depth and how the mix
-    responds to note velocity.
-    """)]
+Settings defining the base delay time, modulation depth and how the mix
+responds to note velocity.
+""")]
     public struct Settings
     {
-        [SynthDescription("""Initial delay in milliseconds before modulation.""")]
+        [SynthDescription("""
+Initial delay in milliseconds before modulation.
+""")]
         public int DelayMs;
 
-        [SynthDescription("""Amount the delay is modulated in milliseconds.""")]
+        [SynthDescription("""
+Amount the delay is modulated in milliseconds.
+""")]
         public int DepthMs;
 
-        [SynthDescription("""Speed of the modulation LFO in hertz.""")]
+        [SynthDescription("""
+Speed of the modulation LFO in hertz.
+""")]
         public float RateHz;
 
-        [SynthDescription("""Mix between the original and modulated signals
-        (0 = dry, 1 = fully wet).""")]
+        [SynthDescription("""
+Mix between the original and modulated signals
+(0 = dry, 1 = fully wet).
+""")]
         public float Mix;
 
-        [SynthDescription("""If true, note velocity affects the wet/dry mix.""")]
+        [SynthDescription("""
+If true, note velocity affects the wet/dry mix.
+""")]
         public bool VelocityAffectsMix;
 
-        [SynthDescription("""Function converting velocity to a mix multiplier.""")]
+        [SynthDescription("""
+Function converting velocity to a mix multiplier.
+""")]
         public Func<float, float>? MixVelocityCurve;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/TiltEQEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/TiltEQEffect.cs
@@ -22,17 +22,21 @@ public sealed class TiltEQEffect : Recyclable, IEffect
     private TiltEQEffect() { }
 
     [SynthDescription("""
-    Settings defining the tilt amount and the cutoff frequency used by the
-    internal low‑pass filter.
-    """)]
+Settings defining the tilt amount and the cutoff frequency used by the
+internal low‑pass filter.
+""")]
     public struct Settings
     {
-        [SynthDescription("""Tilt amount from -1 (bass boost) to +1 (treble
-        boost).""")]
+        [SynthDescription("""
+Tilt amount from -1 (bass boost) to +1 (treble
+boost).
+""")]
         public float Tilt;
 
-        [SynthDescription("""Cutoff frequency for the internal low-pass filter in
-        hertz.""")]
+        [SynthDescription("""
+Cutoff frequency for the internal low-pass filter in
+hertz.
+""")]
         public float CutoffHz;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/ToneStackEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/ToneStackEffect.cs
@@ -34,26 +34,36 @@ public sealed class ToneStackEffect : Recyclable, IEffect
     private ToneStackEffect() { }
 
     [SynthDescription("""
-    Settings controlling the bass, mid and treble gains and optional
-    velocity-based scaling.
-    """)]
+Settings controlling the bass, mid and treble gains and optional
+velocity-based scaling.
+""")]
     public struct Settings
     {
-        [SynthDescription("""Linear gain applied to the low frequencies.""")]
+        [SynthDescription("""
+Linear gain applied to the low frequencies.
+""")]
         public float Bass;
 
-        [SynthDescription("""Linear gain applied to the midrange.""")]
+        [SynthDescription("""
+Linear gain applied to the midrange.
+""")]
         public float Mid;
 
-        [SynthDescription("""Linear gain applied to the high frequencies.""")]
+        [SynthDescription("""
+Linear gain applied to the high frequencies.
+""")]
         public float Treble;
 
-        [SynthDescription("""If true, note velocity scales the bass, mid and
-        treble gains.""")]
+        [SynthDescription("""
+If true, note velocity scales the bass, mid and
+treble gains.
+""")]
         public bool VelocityAffectsGain;
 
-        [SynthDescription("""Function mapping velocity to a gain multiplier
-        applied to all bands.""")]
+        [SynthDescription("""
+Function mapping velocity to a gain multiplier
+applied to all bands.
+""")]
         public Func<float, float>? GainVelocityCurve;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/TremoloEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/TremoloEffect.cs
@@ -17,22 +17,30 @@ public class TremoloEffect : Recyclable, IEffect
     protected TremoloEffect() { }
 
     [SynthDescription("""
-    Settings for tremolo depth, rate and optional velocity-based scaling.
-    """)]
+Settings for tremolo depth, rate and optional velocity-based scaling.
+""")]
     public struct Settings
     {
-        [SynthDescription("""Amount of volume modulation from 0 (none) to 1
-        (full).""")]
+        [SynthDescription("""
+Amount of volume modulation from 0 (none) to 1
+(full).
+""")]
         public float Depth;
 
-        [SynthDescription("""Frequency of the modulation LFO in hertz.""")]
+        [SynthDescription("""
+Frequency of the modulation LFO in hertz.
+""")]
         public float RateHz;
 
-        [SynthDescription("""If true, note velocity changes the modulation
-        depth.""")]
+        [SynthDescription("""
+If true, note velocity changes the modulation
+depth.
+""")]
         public bool VelocityAffectsDepth;
 
-        [SynthDescription("""Function mapping velocity to a depth multiplier.""")]
+        [SynthDescription("""
+Function mapping velocity to a depth multiplier.
+""")]
         public Func<float, float>? DepthVelocityCurve;
     }
 

--- a/src/klooie/Audio/SignalProcessing/Effects/VolumeEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/VolumeEffect.cs
@@ -28,15 +28,21 @@ Settings defining the fixed gain and optional velocity response.
 """)]
 public struct Settings
 {
-    [SynthDescription("""Gain multiplier applied to the input signal.""")]
+    [SynthDescription("""
+Gain multiplier applied to the input signal.
+""")]
     public float Gain;
 
-    [SynthDescription("""Function that converts note velocity into a gain
-    multiplier.""")]
+    [SynthDescription("""
+Function that converts note velocity into a gain
+multiplier.
+""")]
     public Func<float, float>? VelocityCurve;
 
-    [SynthDescription("""Additional multiplier applied after the velocity
-    curve.""")]
+    [SynthDescription("""
+Additional multiplier applied after the velocity
+curve.
+""")]
     public float VelocityScale;
 }
 

--- a/src/klooie/Audio/SignalProcessing/Patches/LayeredPatch.cs
+++ b/src/klooie/Audio/SignalProcessing/Patches/LayeredPatch.cs
@@ -124,26 +124,34 @@ public sealed class LayeredPatch : Recyclable, ISynthPatch, ICompositePatch
     }
 
     [SynthDescription("""
-    Configuration describing which patches are layered together and
-    how each layer is mixed in terms of volume, pan position and
-    transpose amount.
-    """)]
+Configuration describing which patches are layered together and
+how each layer is mixed in terms of volume, pan position and
+transpose amount.
+""")]
     public struct Settings
     {
-        [SynthDescription("""Array of patches that will play at the same time.  The
-        index of each patch matches the entries in Volumes, Pans and Transposes.""")]
+        [SynthDescription("""
+Array of patches that will play at the same time.  The
+index of each patch matches the entries in Volumes, Pans and Transposes.
+""")]
         public ISynthPatch[] Patches;
 
-        [SynthDescription("""Relative volume of each layer from 0 to 1.  Values
-        above 1 will boost that layer while values below 1 reduce it.""")]
+        [SynthDescription("""
+Relative volume of each layer from 0 to 1.  Values
+above 1 will boost that layer while values below 1 reduce it.
+""")]
         public float[]? Volumes;
 
-        [SynthDescription("""Stereo pan for each layer where -1 is full left and
-        +1 is full right.""")]
+        [SynthDescription("""
+Stereo pan for each layer where -1 is full left and
++1 is full right.
+""")]
         public float[]? Pans;
 
-        [SynthDescription("""Number of semitones each layer is transposed
-        relative to the original pitch.""")]
+        [SynthDescription("""
+Number of semitones each layer is transposed
+relative to the original pitch.
+""")]
         public int[]? Transposes;
     }
 }

--- a/src/klooie/Audio/SignalProcessing/Patches/PowerChordPatch.cs
+++ b/src/klooie/Audio/SignalProcessing/Patches/PowerChordPatch.cs
@@ -136,25 +136,33 @@ public class PowerChordPatch : Recyclable, ISynthPatch, ICompositePatch
     }
 
     [SynthDescription("""
-    Settings describing which patch to copy for each chord tone along with
-    detune and stereo spread options.
-    """)]
+Settings describing which patch to copy for each chord tone along with
+detune and stereo spread options.
+""")]
     public struct Settings
     {
-        [SynthDescription("""The base patch that will be duplicated for each
-        chord note.""")]
+        [SynthDescription("""
+The base patch that will be duplicated for each
+chord note.
+""")]
         public ISynthPatch BasePatch;
 
-        [SynthDescription("""Array of semitone offsets defining the chord
-        intervals.""")]
+        [SynthDescription("""
+Array of semitone offsets defining the chord
+intervals.
+""")]
         public int[]? Intervals;
 
-        [SynthDescription("""Total detune range applied across the layers in
-        cents.""")]
+        [SynthDescription("""
+Total detune range applied across the layers in
+cents.
+""")]
         public float DetuneCents;
 
-        [SynthDescription("""Stereo spread of the layers where -1 is far left
-        and +1 is far right.""")]
+        [SynthDescription("""
+Stereo spread of the layers where -1 is far left
+and +1 is far right.
+""")]
         public float PanSpread;
     }
 }

--- a/src/klooie/Audio/SignalProcessing/Patches/UnisonPatch.cs
+++ b/src/klooie/Audio/SignalProcessing/Patches/UnisonPatch.cs
@@ -126,23 +126,31 @@ public class UnisonPatch : Recyclable, ISynthPatch, ICompositePatch
     }
 
     [SynthDescription("""
-    Settings describing the base patch and how many detuned voices to create
-    along with their pan spread.
-    """)]
+Settings describing the base patch and how many detuned voices to create
+along with their pan spread.
+""")]
     public struct Settings
     {
-        [SynthDescription("""Patch that will be duplicated for every voice.""")]
+        [SynthDescription("""
+Patch that will be duplicated for every voice.
+""")]
         public ISynthPatch BasePatch;
 
-        [SynthDescription("""How many detuned voices to spawn.""")]
+        [SynthDescription("""
+How many detuned voices to spawn.
+""")]
         public int NumVoices;
 
-        [SynthDescription("""Total amount of detuning across all voices in
-        cents.""")]
+        [SynthDescription("""
+Total amount of detuning across all voices in
+cents.
+""")]
         public float DetuneCents;
 
-        [SynthDescription("""Stereo spread of the voices where -1 is hard left
-        and +1 is hard right.""")]
+        [SynthDescription("""
+Stereo spread of the voices where -1 is hard left
+and +1 is hard right.
+""")]
         public float PanSpread;
     }
 }


### PR DESCRIPTION
## Summary
- reformat all `[SynthDescription]` attributes to use multiline raw string literals
- remove indentation from description text

## Testing
- `dotnet test src/klooie.sln --no-build --nologo -v q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a845ccef483259af1d2c0ceb74e9a