### PR TITLE
Enable note-aware filters and EQs

### DIFF
--- a/src/klooie/Audio/SignalProcessing/Effects/HighPassFilterEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/HighPassFilterEffect.cs
@@ -2,8 +2,11 @@ using System;
 
 namespace klooie;
 [SynthDescription("""
-Basic high-pass filter for removing low frequencies below the chosen cutoff.
-Cutoff can be either an absolute frequency or a multiple of the note's fundamental frequency.
+Basic high-pass filter that removes rumble and low-end energy.
+You can provide a fixed cutoff in hertz or specify a multiplier
+of the note's pitch so the filter tracks the note. Use a fixed
+cutoff to clean up sub bass, or a multiplier for patches that
+stay consistent across the keyboard.
 """)]
 [SynthCategory("Filter")]
 public class HighPassFilterEffect : Recyclable, IEffect
@@ -33,7 +36,7 @@ Fixed cutoff frequency in hertz. Must not be set if NoteFrequencyMultiplier is s
         public float? CutoffHz;
 
         [SynthDescription("""
-If set, cutoff frequency is computed as note frequency × this multiplier.
+If set, cutoff frequency is computed as note frequency Ã— this multiplier.
 Must not be set if CutoffHz is set.
 """)]
         public float? NoteFrequencyMultiplier;

--- a/src/klooie/Audio/SignalProcessing/Effects/TiltEQEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/TiltEQEffect.cs
@@ -7,8 +7,10 @@ namespace klooie;
 /// Positive <c>tilt</c> brightens; negative warms.
 /// </summary>
 [SynthDescription("""
-Tilt EQ that boosts highs while cutting lows (or the reverse) around a chosen
-cutoff frequency.
+Tilt EQ that boosts highs while cutting lows (or the reverse).
+The internal low‑pass cutoff may be a fixed frequency or a
+multiple of the played note. Use the multiplier when you want
+the tilt to track the note's pitch.
 """)]
 [SynthCategory("Filter")]
 public sealed class TiltEQEffect : Recyclable, IEffect
@@ -16,15 +18,17 @@ public sealed class TiltEQEffect : Recyclable, IEffect
     private float tilt;     // -1 (bass boost) … +1 (treble boost)
     private float alpha;    // LPF coefficient computed from cutoff
     private float low;      // running low-passed state
-    private float cutoffHz;
+    private float? fixedCutoffHz;
+    private float? noteFrequencyMultiplier;
 
     private static readonly LazyPool<TiltEQEffect> _pool = new(() => new TiltEQEffect());
     private TiltEQEffect() { }
 
     [SynthDescription("""
-Settings defining the tilt amount and the cutoff frequency used by the
-internal low‑pass filter.
-""")]
+    Settings defining the tilt amount and how the low‑pass cutoff
+    is determined. Provide either a fixed cutoff or a multiplier
+    of the note frequency so the EQ follows the pitch.
+    """)]
     public struct Settings
     {
         [SynthDescription("""
@@ -34,26 +38,39 @@ boost).
         public float Tilt;
 
         [SynthDescription("""
-Cutoff frequency for the internal low-pass filter in
-hertz.
-""")]
-        public float CutoffHz;
+        Fixed cutoff for the internal low-pass in hertz. Leave
+        null to use NoteFrequencyMultiplier.
+        """)]
+        public float? CutoffHz;
+
+        [SynthDescription("""
+        If set, cutoff = note frequency × this multiplier. Leave
+        null to use CutoffHz.
+        """)]
+        public float? NoteFrequencyMultiplier;
     }
 
     public static TiltEQEffect Create(in Settings settings)
     {
+        if (settings.CutoffHz.HasValue == settings.NoteFrequencyMultiplier.HasValue)
+            throw new ArgumentException("Specify exactly one of CutoffHz or NoteFrequencyMultiplier.");
+
         var fx = _pool.Value.Rent();
-        fx.Construct(settings.Tilt, settings.CutoffHz);
+        fx.Construct(in settings);
         return fx;
     }
 
-    private void Construct(float tilt, float cutoffHz)
+    private void Construct(in Settings settings)
     {
-        this.tilt = tilt;
-        this.cutoffHz = cutoffHz;
-        float dt = 1f / SoundProvider.SampleRate;
-        float rc = 1f / (2f * MathF.PI * cutoffHz);
-        alpha = dt / (rc + dt);
+        tilt = settings.Tilt;
+        fixedCutoffHz = settings.CutoffHz;
+        noteFrequencyMultiplier = settings.NoteFrequencyMultiplier;
+        if (fixedCutoffHz.HasValue)
+        {
+            float dt = 1f / SoundProvider.SampleRate;
+            float rc = 1f / (2f * MathF.PI * fixedCutoffHz.Value);
+            alpha = dt / (rc + dt);
+        }
         low = 0f;
     }
 
@@ -62,7 +79,8 @@ hertz.
         var settings = new Settings
         {
             Tilt = tilt,
-            CutoffHz = cutoffHz
+            CutoffHz = fixedCutoffHz,
+            NoteFrequencyMultiplier = noteFrequencyMultiplier
         };
         return Create(in settings);
     }
@@ -70,8 +88,16 @@ hertz.
     public float Process(in EffectContext ctx)
     {
         float input = ctx.Input;
+        float a = alpha;
+        if (!fixedCutoffHz.HasValue)
+        {
+            float cutoff = ctx.Note.FrequencyHz * noteFrequencyMultiplier!.Value;
+            float dt = 1f / SoundProvider.SampleRate;
+            float rc = 1f / (2f * MathF.PI * cutoff);
+            a = dt / (rc + dt);
+        }
         /* split ---------------------------------------------------------------*/
-        low += alpha * (input - low);          // 1-pole LP -> "bass"
+        low += a * (input - low);          // 1-pole LP -> "bass"
         float high = input - low;              // residual  -> "treble"
 
         /* tilt mix --------------------------------------------------------------*/
@@ -82,7 +108,8 @@ hertz.
     protected override void OnReturn()
     {
         tilt = alpha = low = 0f;
-        cutoffHz = 0f;
+        fixedCutoffHz = null;
+        noteFrequencyMultiplier = null;
         base.OnReturn();
     }
 }

--- a/src/klooie/Audio/SignalProcessing/Patches/SynthPatch.cs
+++ b/src/klooie/Audio/SignalProcessing/Patches/SynthPatch.cs
@@ -209,6 +209,17 @@ public static class SynthPatchExtensions
         return patch.WithEffect(LowPassFilterEffect.Create(in settings));
     }
 
+    public static ISynthPatch WithLowPassRelative(this ISynthPatch patch, float multiplier = 1f)
+    {
+        var settings = new LowPassFilterEffect.Settings
+        {
+            NoteFrequencyMultiplier = multiplier,
+            Mix = 1f,
+            VelocityAffectsMix = true
+        };
+        return patch.WithEffect(LowPassFilterEffect.Create(in settings));
+    }
+
     public static ISynthPatch WithDistortion(this ISynthPatch patch, float drive = 6f, float stageRatio = 0.6f, float bias = 0.15f)
     {
         var settings = new DistortionEffect.Settings
@@ -362,6 +373,20 @@ public static class SynthPatchExtensions
         return patch.WithEffect(ParametricEQEffect.Create(in settings));
     }
 
+    public static ISynthPatch WithPeakEQRelative(this ISynthPatch patch, float multiplier, float gainDb, float q = 1.0f)
+    {
+        var settings = new ParametricEQEffect.Settings
+        {
+            Type = BiquadType.Peak,
+            NoteFrequencyMultiplier = multiplier,
+            GainDb = gainDb,
+            Q = q,
+            VelocityAffectsGain = true,
+            GainVelocityScale = 1f
+        };
+        return patch.WithEffect(ParametricEQEffect.Create(in settings));
+    }
+
     public static ISynthPatch WithLowShelf(this ISynthPatch patch, float freq, float gainDb)
     {
         var settings = new ParametricEQEffect.Settings
@@ -376,12 +401,40 @@ public static class SynthPatchExtensions
         return patch.WithEffect(ParametricEQEffect.Create(in settings));
     }
 
+    public static ISynthPatch WithLowShelfRelative(this ISynthPatch patch, float multiplier, float gainDb)
+    {
+        var settings = new ParametricEQEffect.Settings
+        {
+            Type = BiquadType.LowShelf,
+            NoteFrequencyMultiplier = multiplier,
+            GainDb = gainDb,
+            Q = 1f,
+            VelocityAffectsGain = true,
+            GainVelocityScale = 1f
+        };
+        return patch.WithEffect(ParametricEQEffect.Create(in settings));
+    }
+
     public static ISynthPatch WithHighShelf(this ISynthPatch patch, float freq, float gainDb)
     {
         var settings = new ParametricEQEffect.Settings
         {
             Type = BiquadType.HighShelf,
             Freq = freq,
+            GainDb = gainDb,
+            Q = 1f,
+            VelocityAffectsGain = true,
+            GainVelocityScale = 1f
+        };
+        return patch.WithEffect(ParametricEQEffect.Create(in settings));
+    }
+
+    public static ISynthPatch WithHighShelfRelative(this ISynthPatch patch, float multiplier, float gainDb)
+    {
+        var settings = new ParametricEQEffect.Settings
+        {
+            Type = BiquadType.HighShelf,
+            NoteFrequencyMultiplier = multiplier,
             GainDb = gainDb,
             Q = 1f,
             VelocityAffectsGain = true,


### PR DESCRIPTION
## Summary
- support note-based cutoff for `LowPassFilterEffect`
- add note-aware mode to `TiltEQEffect`
- implement relative frequency option for `ParametricEQEffect`
- expand `HighPassFilterEffect` docs
- expose relative frequency helpers in `SynthPatch` extensions

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bb680fdd08325bc9d98f14b03f50b