### PR TITLE
Support method-level synth documentation

### DIFF
--- a/src/klooie/Audio/SignalProcessing/Instruments/DrumKit.cs
+++ b/src/klooie/Audio/SignalProcessing/Instruments/DrumKit.cs
@@ -1,15 +1,16 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace klooie;
 
-[SynthCategory("Drums")]
-[SynthDocumentation("""
-A basic kick drum patch with a punchy attack and a short decay.
-""")]
-public static class KickOne
+public static class DrumKit
 {
     private const float Duration = .18f;
-    public static ISynthPatch Create() => LayeredPatch.CreateBuilder()
+
+    [SynthCategory("Drums")]
+    [SynthDocumentation("""
+A basic kick drum patch with a punchy attack and a short decay.
+""")]
+    public static ISynthPatch KickClassic() => LayeredPatch.CreateBuilder()
         .AddLayer(patch: SynthPatch.Create()
             .WithWaveForm(WaveformType.Sine)
             .WithEnvelope(0f, Duration, 0f, 0.02f)
@@ -23,6 +24,10 @@ public static class KickOne
             .WithVolume(.03f))
         .Build()
         .WithVolume(1f);
+
+    [SynthCategory("Drums")]
+    [SynthDocumentation("A softer kick drum with lower output level.")]
+    public static ISynthPatch KickSoft() => KickClassic().WithVolume(0.7f);
 
     private static float KickPitchBend(float time)
     {

--- a/src/klooie/Audio/SignalProcessing/SynthDocAttributes.cs
+++ b/src/klooie/Audio/SignalProcessing/SynthDocAttributes.cs
@@ -1,13 +1,13 @@
 namespace klooie;
 
-[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Field | AttributeTargets.Parameter)]
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Method)]
 public sealed class SynthDocumentationAttribute : Attribute
 {
     public string Markdown { get; }
     public SynthDocumentationAttribute(string markdown) => Markdown = markdown;
 }
 
-[AttributeUsage(AttributeTargets.Class)]
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
 public sealed class SynthCategoryAttribute : Attribute
 {
     public string Category { get; }

--- a/src/klooie/Audio/SignalProcessing/SynthDocGenerator.cs
+++ b/src/klooie/Audio/SignalProcessing/SynthDocGenerator.cs
@@ -111,6 +111,7 @@ public static class SynthDocGenerator
 
         var effectDocs = CollectDocs(allTypes, effectType, allExtensionDocs);
         var patchDocs = CollectDocs(allTypes, patchType, allExtensionDocs);
+        patchDocs.AddRange(CollectFactoryMethodDocs(allTypes, patchType));
 
         return new List<SectionDoc>
         {
@@ -174,6 +175,24 @@ public static class SynthDocGenerator
                 .ToList();
 
             docs.Add(new ItemDoc(cat.Category, type.Name, desc.Markdown, paramDoc, extensions));
+        }
+        return docs;
+    }
+
+    private static List<ItemDoc> CollectFactoryMethodDocs(IEnumerable<Type> types, Type baseType)
+    {
+        var docs = new List<ItemDoc>();
+        foreach (var type in types)
+        {
+            foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.Static))
+            {
+                if (method.ReturnType != baseType) continue;
+                var desc = method.GetCustomAttribute<SynthDocumentationAttribute>();
+                var cat = method.GetCustomAttribute<SynthCategoryAttribute>();
+                if (desc == null || cat == null) continue;
+
+                docs.Add(new ItemDoc(cat.Category, method.Name, desc.Markdown, null, new List<ExtensionDoc>()));
+            }
         }
         return docs;
     }
@@ -471,7 +490,7 @@ public static class SynthDocGenerator
     <div id="home" class="section active">
         <h1>Welcome to the Synth Documentation</h1>
         <p>This interactive documentation gives you a deep dive into every synth effect and patch available in your system.</p>
-        <p>Select a category on the left under <b>Patches</b> or <b>Effects</b> to explore your custom audio engine’s palette of sounds and creative tools.</p>
+        <p>Select a category on the left under <b>Patches</b> or <b>Effects</b> to explore your custom audio engines palette of sounds and creative tools.</p>
         <p>Each effect and patch includes detailed descriptions, parameter explanations, and C# extension method examples for fast prototyping.</p>
     </div>
     """);


### PR DESCRIPTION
## Summary
- allow SynthDocumentation and SynthCategory to be placed on methods
- include static factory methods in SynthDocGenerator
- rewrite Kick instrument to demonstrate new pattern

## Testing
- `dotnet test src/klooie.sln --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883b6b9e06083258806dad90f53ddc2