### PR TITLE
Add portamento and scheduled note context

### DIFF
--- a/src/klooie/Audio/SignalProcessing/EffectContext.cs
+++ b/src/klooie/Audio/SignalProcessing/EffectContext.cs
@@ -7,7 +7,8 @@ public struct EffectContext
     public float Input;
     public int FrameIndex;
     public float Time;
-    public NoteExpression Note;
+    public ScheduledNoteEvent NoteEvent;
+    public NoteExpression Note => NoteEvent.Note;
     public float VelocityNorm => Note.Velocity / 127f;
 
     public static float EaseLinear(float t) => t;
@@ -32,5 +33,6 @@ public struct PitchModContext
 {
     public float Time;
     public float? ReleaseTime;
-    public NoteExpression Note;
+    public ScheduledNoteEvent NoteEvent;
+    public NoteExpression Note => NoteEvent.Note;
 }

--- a/src/klooie/Audio/SignalProcessing/Effects/PortamentoEffect.cs
+++ b/src/klooie/Audio/SignalProcessing/Effects/PortamentoEffect.cs
@@ -1,0 +1,46 @@
+using System;
+
+namespace klooie;
+
+[SynthCategory("Modulation")]
+public class PortamentoEffect : Recyclable, IPitchModEffect
+{
+    private float glideSeconds;
+    private static readonly LazyPool<PortamentoEffect> _pool = new(() => new PortamentoEffect());
+    private PortamentoEffect() { }
+
+    public struct Settings
+    {
+        public float GlideSeconds;
+    }
+
+    public static PortamentoEffect Create(in Settings settings)
+    {
+        var fx = _pool.Value.Rent();
+        fx.glideSeconds = settings.GlideSeconds;
+        return fx;
+    }
+
+    public float GetPitchOffsetCents(in PitchModContext ctx)
+    {
+        var next = ctx.NoteEvent.Next;
+        if (next == null) return 0f;
+
+        float diffCents = (next.Note.MidiNote - ctx.NoteEvent.Note.MidiNote) * 100f;
+        float timeToNext = (float)(next.Note.StartTime - ctx.NoteEvent.Note.StartTime).TotalSeconds;
+        float dur = MathF.Min(glideSeconds, timeToNext);
+        if (dur <= 0) return diffCents;
+        float t = MathF.Min(ctx.Time, dur);
+        return diffCents * (t / dur);
+    }
+
+    public float Process(in EffectContext ctx) => ctx.Input;
+
+    public IEffect Clone() => Create(new Settings { GlideSeconds = glideSeconds });
+
+    protected override void OnReturn()
+    {
+        glideSeconds = 0f;
+        base.OnReturn();
+    }
+}

--- a/src/klooie/Audio/SignalProcessing/Patches/LayeredPatch.cs
+++ b/src/klooie/Audio/SignalProcessing/Patches/LayeredPatch.cs
@@ -72,7 +72,7 @@ public sealed class LayeredPatch : Recyclable, ISynthPatch, ICompositePatch
     public void SpawnVoices(
         float freq,
         VolumeKnob master,
-        NoteExpression note,
+        ScheduledNoteEvent noteEvent,
         List<SynthSignalSource> outVoices)
     {
         for (int i = 0; i < layers.Length; i++)
@@ -81,7 +81,7 @@ public sealed class LayeredPatch : Recyclable, ISynthPatch, ICompositePatch
                 ? freq
                 : freq * MathF.Pow(2f, layerTransposes[i] / 12f);
 
-            layers[i].SpawnVoices(transFreq, master, note, outVoices);
+            layers[i].SpawnVoices(transFreq, master, noteEvent, outVoices);
         }
     }
 

--- a/src/klooie/Audio/SignalProcessing/Patches/PowerChordPatch.cs
+++ b/src/klooie/Audio/SignalProcessing/Patches/PowerChordPatch.cs
@@ -65,7 +65,7 @@ public class PowerChordPatch : Recyclable, ISynthPatch, ICompositePatch
             patches[i] = layerPatch; }
     }
 
-    public void SpawnVoices(float frequencyHz, VolumeKnob master, NoteExpression note, List<SynthSignalSource> outVoices)
+    public void SpawnVoices(float frequencyHz, VolumeKnob master, ScheduledNoteEvent noteEvent, List<SynthSignalSource> outVoices)
     {
         int numLayers = intervals.Length;
         for (int i = 0; i < numLayers; i++)
@@ -85,7 +85,7 @@ public class PowerChordPatch : Recyclable, ISynthPatch, ICompositePatch
                 patches[i].GetAllLeafPatches(leaves);
                 foreach (var leaf in leaves.Items)
                 {
-                    outVoices.Add(SynthSignalSource.Create(freq, (SynthPatch)leaf, master, note));
+                    outVoices.Add(SynthSignalSource.Create(freq, (SynthPatch)leaf, master, noteEvent));
                 }
             }
             finally

--- a/src/klooie/Audio/SignalProcessing/Patches/ReverbPatch.cs
+++ b/src/klooie/Audio/SignalProcessing/Patches/ReverbPatch.cs
@@ -65,10 +65,10 @@ public class ReverbPatch : Recyclable, ISynthPatch, ICompositePatch
         buffer.Add(wet);
     }
 
-    public void SpawnVoices(float frequencyHz, VolumeKnob master, NoteExpression note, List<SynthSignalSource> outVoices)
+    public void SpawnVoices(float frequencyHz, VolumeKnob master, ScheduledNoteEvent noteEvent, List<SynthSignalSource> outVoices)
     {
-        dry.SpawnVoices(frequencyHz, master, note, outVoices);
-        wet.SpawnVoices(frequencyHz, master, note, outVoices);
+        dry.SpawnVoices(frequencyHz, master, noteEvent, outVoices);
+        wet.SpawnVoices(frequencyHz, master, noteEvent, outVoices);
     }
 
     protected override void OnReturn()

--- a/src/klooie/Audio/SignalProcessing/Patches/SynthPatch.cs
+++ b/src/klooie/Audio/SignalProcessing/Patches/SynthPatch.cs
@@ -14,7 +14,7 @@ public interface ICompositePatch : ISynthPatch
 public interface ISynthPatch
 {
     bool IsNotePlayable(int midiNote) => true;  // default: always playable
-    void SpawnVoices(float frequencyHz, VolumeKnob master, NoteExpression note, List<SynthSignalSource> outVoices);
+    void SpawnVoices(float frequencyHz, VolumeKnob master, ScheduledNoteEvent noteEvent, List<SynthSignalSource> outVoices);
     ISynthPatch Clone();
 }
 
@@ -128,9 +128,9 @@ public class SynthPatch : Recyclable, ISynthPatch
         Effects = null!;
     }
 
-    public virtual void SpawnVoices(float frequencyHz, VolumeKnob master, NoteExpression note, List<SynthSignalSource> outVoices)
+    public virtual void SpawnVoices(float frequencyHz, VolumeKnob master, ScheduledNoteEvent noteEvent, List<SynthSignalSource> outVoices)
     {
-        var innerVoice = SynthSignalSource.Create(frequencyHz, this, master, note);
+        var innerVoice = SynthSignalSource.Create(frequencyHz, this, master, noteEvent);
         this.OnDisposed(innerVoice, Recyclable.TryDisposeMe);
         outVoices.Add(innerVoice);
     }

--- a/src/klooie/Audio/SignalProcessing/Patches/SynthPatchExtensions.cs
+++ b/src/klooie/Audio/SignalProcessing/Patches/SynthPatchExtensions.cs
@@ -204,6 +204,13 @@ public static class SynthPatchExtensions
         return patch.WithEffect(PitchBendEffect.Create(in settings));
     }
 
+    [ExtensionToEffect(typeof(PortamentoEffect))]
+    public static ISynthPatch WithPortamento(this ISynthPatch patch, float glideSeconds = 0.05f)
+    {
+        var settings = new PortamentoEffect.Settings { GlideSeconds = glideSeconds };
+        return patch.WithEffect(PortamentoEffect.Create(in settings));
+    }
+
     [ExtensionToEffect(typeof(NoiseGateEffect))]
     public static ISynthPatch WithNoiseGate(this ISynthPatch patch, float openThresh = 0.05f, float closeThresh = 0.04f, float attackMs = 2f, float releaseMs = 60f)
     {

--- a/src/klooie/Audio/SignalProcessing/Patches/UnisonPatch.cs
+++ b/src/klooie/Audio/SignalProcessing/Patches/UnisonPatch.cs
@@ -61,7 +61,7 @@ public class UnisonPatch : Recyclable, ISynthPatch, ICompositePatch
     public void SpawnVoices(
         float frequencyHz,
         VolumeKnob master,
-        NoteExpression note,
+        ScheduledNoteEvent noteEvent,
         List<SynthSignalSource> outVoices)
     {
         for (int i = 0; i < numVoices; i++)
@@ -79,7 +79,7 @@ public class UnisonPatch : Recyclable, ISynthPatch, ICompositePatch
                 {
                     if (leaf is SynthPatch synthLeaf)
                     {
-                        outVoices.Add(SynthSignalSource.Create(detunedFreq, synthLeaf, master, note));
+                        outVoices.Add(SynthSignalSource.Create(detunedFreq, synthLeaf, master, noteEvent));
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- add new `PortamentoEffect` and extension
- plumb `ScheduledNoteEvent` into synth effects and pitch mods
- spawn voices in the scheduler instead of the UI thread
- update patches and audio engine for new scheduling logic

## Testing
- `dotnet test` *(fails: `command not found: dotnet`)*

------
https://chatgpt.com/codex/tasks/task_e_6884d7b0e9b883258c142d24c162170f