### PR TITLE
Prefer MathF and floats in geometry

### DIFF
--- a/src/klooie/Geometry/Angle.cs
+++ b/src/klooie/Geometry/Angle.cs
@@ -29,19 +29,19 @@ public readonly struct Angle
     /// <summary>
     /// points up and to the left
     /// </summary>
-    public static readonly Angle UpLeft = (Up.Value + Left.Value) / 2;
+    public static readonly Angle UpLeft = (Up.Value + Left.Value) / 2f;
     /// <summary>
     /// points up and to the right
     /// </summary>
-    public static readonly Angle UpRight = (Up.Value + 360) / 2;
+    public static readonly Angle UpRight = (Up.Value + 360f) / 2f;
     /// <summary>
     /// points down and to the right
     /// </summary>
-    public static readonly Angle DownRight = (Down.Value + Right.Value) / 2;
+    public static readonly Angle DownRight = (Down.Value + Right.Value) / 2f;
     /// <summary>
     /// points down and to the left
     /// </summary>
-    public static readonly Angle DownLeft = (Down.Value + Left.Value) / 2;
+    public static readonly Angle DownLeft = (Down.Value + Left.Value) / 2f;
 
     /// <summary>
     /// the angle value as a float between 0 (inclusive) and 360 (exclusive)
@@ -80,7 +80,7 @@ public readonly struct Angle
         Value = Normalize360(val);
     }
 
-    public static Angle FromRadians(float radians) => radians * (180 / MathF.PI);
+    public static Angle FromRadians(float radians) => radians * (180f / MathF.PI);
 
     public float ToRadians() => Value * (MathF.PI / 180f);
     
@@ -136,9 +136,9 @@ public readonly struct Angle
     public Angle Add(float other)
     {
         var ret = Value + other;
-        ret = ret % 360;
-        ret = ret >= 0 ? ret : ret + 360;
-        if (ret == 360) return new Angle(0);
+        ret %= 360f;
+        ret = ret >= 0f ? ret : ret + 360f;
+        if (ret == 360f) return new Angle(0f);
         return new Angle(ret);
     }
 
@@ -153,7 +153,7 @@ public readonly struct Angle
     /// Gets the angle that is 180 degrees away from the current angle
     /// </summary>
     /// <returns>the angle that is 180 degrees away from the current angle</returns>
-    public Angle Opposite() => Add(180);
+    public Angle Opposite() => Add(180f);
 
     /// <summary>
     /// Uses the shortest path to get the # of degrees between this angle and another one.
@@ -162,9 +162,9 @@ public readonly struct Angle
     /// <returns>the # of degrees between this angle and a given other angle</returns>
     public float DiffShortest(Angle other)
     {
-        var c = Math.Abs(Value - other.Value);
-        c = c <= 180 ? c : Math.Abs(360 - c);
-        if (c == 360) return 0;
+        var c = MathF.Abs(Value - other.Value);
+        c = c <= 180f ? c : MathF.Abs(360f - c);
+        if (c == 360f) return 0f;
         return c;
     }
 
@@ -197,7 +197,7 @@ public readonly struct Angle
     /// </summary>
     /// <param name="nearest">The amount to round to (e.g. 90) to round to the nearest NEWS</param>
     /// <returns>a new angle that is the current angle rounded to the nearest angle</returns>
-    public Angle RoundAngleToNearest(Angle nearest) => new Angle(((float)ConsoleMath.Round(Value / nearest.Value) * nearest.Value) % 360);
+    public Angle RoundAngleToNearest(Angle nearest) => new Angle((ConsoleMath.Round(Value / nearest.Value) * nearest.Value) % 360f);
 
     /// <summary>
     /// Determines if Clockwise is the shortest rotational path from this angle to another one
@@ -255,7 +255,7 @@ public readonly struct Angle
     {
         get
         {
-            var tolerance = 30;
+            var tolerance = 30f;
             if (this.DiffShortest(0) <= tolerance || this.DiffShortest(180) <= tolerance || this.DiffShortest(360) <= tolerance)
             {
                 return '-';
@@ -289,14 +289,14 @@ public readonly struct Angle
     /// </summary>
     /// <param name="degrees">the angle in degrees</param>
     /// <returns>the original angle, converted to radians</returns>
-    public static float ToRadians(Angle degrees) => (float)(Math.PI * degrees.Value / 180.0);
+    public static float ToRadians(Angle degrees) => MathF.PI * degrees.Value / 180f;
 
     /// <summary>
     /// Converts radians to an Angle
     /// </summary>
     /// <param name="radians">a number in radians</param>
     /// <returns>An angle in degrees</returns>
-    public static Angle ToDegrees(float radians) => new Angle((float)(radians * (180.0 / Math.PI)) % 360);
+    public static Angle ToDegrees(float radians) => new Angle((radians * (180f / MathF.PI)) % 360f);
 
     /// <summary>
     /// Implicit definition for converting a float into an Angle
@@ -316,7 +316,7 @@ public readonly struct Angle
     {
         if (float.TryParse(val, out float f))
         {
-            if (f < 0 || f >= 360) throw new ValidationArgException($"Angles must be >=0 and < 360, given: {val}");
+            if (f < 0f || f >= 360f) throw new ValidationArgException($"Angles must be >=0 and < 360, given: {val}");
             return new Angle(f);
         }
         else if (nameof(Up).Equals(val, StringComparison.OrdinalIgnoreCase))
@@ -350,6 +350,6 @@ public readonly struct Angle
             yield return initialAngle.Add(increment);
             yield return initialAngle.Add(-increment);
         }
-        yield return initialAngle.Add(180); // 180°
+        yield return initialAngle.Add(180f); // 180°
     }
 }

--- a/src/klooie/Geometry/Circle.cs
+++ b/src/klooie/Geometry/Circle.cs
@@ -177,12 +177,12 @@ public readonly struct Circle
         else
         {
             // Two solutions.
-            t = (float)((-B + Math.Sqrt(det)) / (2 * A));
+            t = (-B + MathF.Sqrt(det)) / (2f * A);
 
             ox1 = x1 + t * dx;
             oy1 = y1 + t * dy;
 
-            t = (float)((-B - Math.Sqrt(det)) / (2 * A));
+            t = (-B - MathF.Sqrt(det)) / (2f * A);
 
             ox2 = x1 + t * dx;
             oy2 = y1 + t * dy;

--- a/src/klooie/Geometry/ConsoleMath.cs
+++ b/src/klooie/Geometry/ConsoleMath.cs
@@ -25,7 +25,7 @@ public static class ConsoleMath
     /// <param name="f">the # to round</param>
     /// <param name="digits">the number of digits to round to</param>
     /// <returns>the rounded number</returns>
-    public static float Round(float f, int digits) => (float)Math.Round(f, digits, MidpointRounding.AwayFromZero);
+    public static float Round(float f, int digits) => MathF.Round(f, digits, MidpointRounding.AwayFromZero);
     
     /// <summary>
     /// Rounds using normal rounding, not banker's rounding
@@ -33,21 +33,21 @@ public static class ConsoleMath
     /// <param name="f">the # to round</param>
     /// <param name="digits">the number of digits to round to</param>
     /// <returns>the rounded number</returns>
-    public static float Round(double d, int digits) => (float)Math.Round(d, digits, MidpointRounding.AwayFromZero);
+    public static float Round(double d, int digits) => MathF.Round((float)d, digits, MidpointRounding.AwayFromZero);
     
     /// <summary>
     /// Rounds to an int using normal rounding, not banker's rounding
     /// </summary>
     /// <param name="f">the number to round</param>
     /// <returns>the rounded number</returns>
-    public static int Round(float f) => (int)Math.Round(f, MidpointRounding.AwayFromZero);
+    public static int Round(float f) => (int)MathF.Round(f, MidpointRounding.AwayFromZero);
 
     /// <summary>
     /// Rounds to an int using normal rounding, not banker's rounding
     /// </summary>
     /// <param name="f">the number to round</param>
     /// <returns>the rounded number</returns>
-    public static int Round(double d) => (int)Math.Round(d, MidpointRounding.AwayFromZero);
+    public static int Round(double d) => (int)MathF.Round((float)d, MidpointRounding.AwayFromZero);
 
 
     /// <summary>
@@ -64,8 +64,8 @@ public static class ConsoleMath
     /// <returns>the normalized quantity</returns>
     public static float NormalizeQuantity(this float quantity, Angle angle, bool reverse = false)
     {
-        var degreesFromFlat = angle.Value <= 180 ? Math.Min(180 - angle.Value, angle.Value) : Math.Min(angle.Value - 180, 360 - angle.Value);
-        var skewPercentage = 1 + (degreesFromFlat / 90);
+        var degreesFromFlat = angle.Value <= 180f ? MathF.Min(180f - angle.Value, angle.Value) : MathF.Min(angle.Value - 180f, 360f - angle.Value);
+        var skewPercentage = 1f + (degreesFromFlat / 90f);
         return reverse ? quantity * skewPercentage : quantity / skewPercentage;
     }
 }

--- a/src/klooie/Geometry/Edge.cs
+++ b/src/klooie/Geometry/Edge.cs
@@ -38,9 +38,9 @@ public readonly struct Edge
         float dy = Y2 - Y1;
 
         float denom = dx * dx + dy * dy;
-        if (denom == 0) return LocF.CalculateDistanceTo(x, y, X1, Y1); // Edge is a point
+        if (denom == 0f) return LocF.CalculateDistanceTo(x, y, X1, Y1); // Edge is a point
         float t = ((x - X1) * dx + (y - Y1) * dy) / denom;
-        t = Math.Clamp(t, 0, 1); // Clamp to edge segment
+        t = MathF.Max(0f, MathF.Min(1f, t)); // Clamp to edge segment
 
         float closestX = X1 + t * dx;
         float closestY = Y1 + t * dy;

--- a/src/klooie/Geometry/LocF.cs
+++ b/src/klooie/Geometry/LocF.cs
@@ -83,7 +83,7 @@ public readonly struct LocF
 
     public LocF RadialOffset(Angle angle, float radius, float aspectRatio = 2.0f)
     {
-        float rad = angle.Value * MathF.PI / 180;
+        float rad = angle.Value * MathF.PI / 180f;
         float x2 = Left + radius * MathF.Cos(rad);
         float y2 = Top + radius * MathF.Sin(rad) / aspectRatio;
         return new LocF(x2, y2);
@@ -109,43 +109,43 @@ public readonly struct LocF
         float dy = b.Top - a.Top;
         float d = a.CalculateDistanceTo(b);
 
-        if (dy == 0 && dx > 0) return 0;
-        else if (dy == 0) return 180;
-        else if (dx == 0 && dy > 0) return 90;
-        else if (dx == 0) return 270;
+        if (dy == 0 && dx > 0) return 0f;
+        else if (dy == 0) return 180f;
+        else if (dx == 0 && dy > 0) return 90f;
+        else if (dx == 0) return 270f;
 
         float radians, increment;
         if (dx >= 0 && dy >= 0)
         {
             // Sin(a) = dy / d
             radians = MathF.Asin(dy / d);
-            increment = 0;
+            increment = 0f;
 
         }
         else if (dx < 0 && dy > 0)
         {
             // Sin(a) = dx / d
             radians = MathF.Asin(-dx / d);
-            increment = 90;
+            increment = 90f;
         }
         else if (dy < 0 && dx < 0)
         {
             radians = MathF.Asin(-dy / d);
-            increment = 180;
+            increment = 180f;
         }
         else if (dx > 0 && dy < 0)
         {
             radians = MathF.Asin(dx / d);
-            increment = 270;
+            increment = 270f;
         }
         else
         {
             throw new Exception($"Failed to calculate angle from {a.Left},{a.Top} to {b.Left},{b.Top}");
         }
 
-        var ret = (increment + radians * 180 / MathF.PI);
+        var ret = increment + radians * 180f / MathF.PI;
 
-        if (ret == 360) ret = 0;
+        if (ret == 360f) ret = 0f;
 
         return ret;
     }

--- a/src/klooie/Geometry/Rect.cs
+++ b/src/klooie/Geometry/Rect.cs
@@ -17,7 +17,7 @@ public readonly struct Rect
     public Loc BottomLeft => new Loc(Left, Bottom);
     public Loc BottomRight => new Loc(Right, Bottom);
 
-    public float Hypotenous => (float)Math.Sqrt(Width * Width + Height * Height);
+    public float Hypotenous => MathF.Sqrt(Width * Width + Height * Height);
 
     public Rect(int x, int y, int w, int h)
     {

--- a/src/tests/Geometry/ConsoleMathTests.cs
+++ b/src/tests/Geometry/ConsoleMathTests.cs
@@ -18,17 +18,17 @@ public class ConsoleMathTests
         var agreed = 0;
         for(var someRandomFloat = 0f; someRandomFloat < 100; someRandomFloat+=.5f)
         {
-            var midPointForThisNumber = Math.Floor(someRandomFloat) + .5f;
+            var midPointForThisNumber = MathF.Floor(someRandomFloat) + .5f;
             var roundedRight = ConsoleMath.Round(someRandomFloat);
-            var roundedLame = (int)Math.Round(someRandomFloat);
+            var roundedLame = (int)MathF.Round(someRandomFloat);
 
             if (someRandomFloat < midPointForThisNumber)
             {
-                Assert.AreEqual(Math.Floor(someRandomFloat), roundedRight);
+                Assert.AreEqual(MathF.Floor(someRandomFloat), roundedRight);
             }
             else
             {
-                Assert.AreEqual(Math.Ceiling(someRandomFloat), roundedRight);
+                Assert.AreEqual(MathF.Ceiling(someRandomFloat), roundedRight);
             }
 
             if(roundedRight != roundedLame)


### PR DESCRIPTION
## Summary
- Replace Math and double-based math in Geometry with MathF and floats
- Use float-specific helpers and clamping to avoid precision losses
- Adjust tests to use MathF for float rounding

## Testing
- ❌ `dotnet test src/klooie.sln` *(dotnet command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689ccac36da48325a6ffd6fb1038d249